### PR TITLE
configurable subjects in the emails

### DIFF
--- a/conf/download_drivers.yaml
+++ b/conf/download_drivers.yaml
@@ -1,9 +1,16 @@
 outbox_directory: ${APROC_DOWNLOAD_OUTBOX_DIR}
 notification_admin_emails: ${APROC_DOWNLOAD_ADMIN_EMAILS}
+
+# Usable variables in messages: {target_projection}, {target_format}, {arlas-user-email}, {item_id}, {asset_name}, {collection}, {target_directory}, {file_name}
+# Usable variables in messages: {error}
+
+email_subject_user: ${APROC_DOWNLOAD_SUBJECT_USER}
 email_content_user: ${APROC_DOWNLOAD_CONTENT_USER}
+email_subject_error_download: ${APROC_DOWNLOAD_SUBJECT_ERROR}
 email_content_error_download: ${APROC_DOWNLOAD_CONTENT_ERROR}
+email_subject_admin: ${APROC_DOWNLOAD_SUBJECT_ADMIN}
 email_content_admin: ${APROC_DOWNLOAD_CONTENT_ADMIN}
-email_content_download_launched_admin: ${APROC_DOWNLOAD_LAUNCHED_ADMIN}
+
 smtp:
   host: ${ARLAS_SMTP_HOST}
   port: ${ARLAS_SMTP_PORT}

--- a/extensions/aproc/proc/download/notifications.py
+++ b/extensions/aproc/proc/download/notifications.py
@@ -12,13 +12,14 @@ class Notifications:
     def init():
         LOGGER.info("SMTP configuration: {}".format(Configuration.settings.smtp.model_dump_json()))
 
-    def try_send_to(msg: str, to: list[str], context: dict[str, str]):
+    def try_send_to(subject: str, msg: str, to: list[str], context: dict[str, str]):
         try:
             if context is not None:
                 msg = msg.format(**context)
+                subject = subject.format(**context)
             email = EmailMessage()
             email.set_content(msg)
-            email['Subject'] = 'ARLAS - Your download request.'
+            email['Subject'] = subject
             email['From'] = Configuration.settings.smtp.from_addr
             email['To'] = ",".join(to)
             client = SMTP(host=Configuration.settings.smtp.host, 

--- a/extensions/aproc/proc/download/settings.py
+++ b/extensions/aproc/proc/download/settings.py
@@ -25,6 +25,9 @@ class Settings(BaseModel, extra='allow'):
     email_content_user: str = Field(title="Content of the email to be sent to the user")
     email_content_error_download: str = Field(title="Content of the email to be sent to the user")
     email_content_admin: str = Field(title="Content of the email to be sent to the admin")
+    email_subject_user: str = Field(title="Subject of the email to be sent to the user")
+    email_subject_error_download: str = Field(title="Subject of the email to be sent to the user")
+    email_subject_admin: str = Field(title="Subject of the email to be sent to the admin")
 
 class Configuration:
     settings: Settings | None = Field(title="aproc Download service configuration")

--- a/test/aproc_ingest_heavyload_tests.py
+++ b/test/aproc_ingest_heavyload_tests.py
@@ -5,7 +5,7 @@ import unittest
 from time import sleep
 
 import requests
-from utils import AIRS_URL, APROC_ENDPOINT, setUpTest
+from utils import AIRS_URL, APROC_ENDPOINT, setUpTest, COLLECTION
 
 from aproc.core.models.ogc.job import StatusCode, StatusInfo
 from aproc.core.processes.processes import Processes
@@ -29,7 +29,7 @@ class Tests(unittest.TestCase):
         print("submitting {} archives".format(BATCH_SIZE))
         for hit in hits:
             url = "https://catalogue.theia-land.fr/arlas/explore/theia/_search?f=metadata.core.identity.identifier%3Aeq%3A{}&righthand=false&pretty=false&flat=false&&&size=1&max-age-cache=120".format(hit["md"]["id"])
-            inputs = InputIngestProcess(url=url, collection="main_collection", catalog="theia")
+            inputs = InputIngestProcess(url=url, collection=COLLECTION, catalog="theia")
             execute = Execute(inputs=inputs.model_dump())
             r = requests.post("/".join([APROC_ENDPOINT, "processes/ingest/execution"]), data=execute.model_dump_json(), headers={"Content-Type": "application/json"})
             self.assertTrue(r.ok)
@@ -46,7 +46,7 @@ class Tests(unittest.TestCase):
         print("{} archives registered in {} s".format(BATCH_SIZE, end - start))
         print("Checking that the {} archives are registered ...".format(BATCH_SIZE))
         for hit in hits:
-            url = AIRS_URL+"/collections/main_collection/items/{}".format(hit["md"]["id"])
+            url = AIRS_URL+"/collections/"+COLLECTION+"/items/{}".format(hit["md"]["id"])
             r = requests.get(url)
             print(".", end="")
             self.assertTrue(r.ok, url+" not found")

--- a/test/aproc_ingest_tests.py
+++ b/test/aproc_ingest_tests.py
@@ -4,8 +4,10 @@ import requests
 import json
 from aproc.core.models.ogc.process import ProcessList, ProcessDescription
 from extensions.aproc.proc.ingest.ingest_process import AprocProcess
-from utils import APROC_ENDPOINT, setUpTest, dir_to_list, filter_data
+
+from utils import APROC_ENDPOINT, setUpTest, dir_to_list, filter_data, AIRS_URL, COLLECTION
 import os
+
 from aproc.core.models.ogc.job import StatusCode, StatusInfo
 from extensions.aproc.proc.ingest.ingest_process import InputIngestProcess
 from aproc.core.models.ogc import (Execute)
@@ -30,11 +32,11 @@ class Tests(unittest.TestCase):
 
     def test_async_ingest_theia(self):
         url = "https://catalogue.theia-land.fr/arlas/explore/theia/_search?f=metadata.core.identity.identifier%3Aeq%3ASENTINEL2A_20230604-105902-526_L2A_T31TCJ_D&righthand=false&pretty=false&flat=false&&&size=1&max-age-cache=120"
-        self.ingest(url, "main_collection", "theia")
+        self.ingest(url, COLLECTION, "theia")
 
     def test_async_ingest_dimap(self):
         url = "/inputs/DIMAP/PROD_SPOT6_001/VOL_SPOT6_001_A/IMG_SPOT6_MS_001_A/"
-        self.ingest(url, "main_collection", "spot6")
+        self.ingest(url, COLLECTION, "spot6")
 
     def test_ingest_folder(self):
         def ingest_folders(data):
@@ -66,7 +68,7 @@ class Tests(unittest.TestCase):
 
     def __ingest_theia(self) -> StatusInfo:
         url = "https://catalogue.theia-land.fr/arlas/explore/theia/_search?f=metadata.core.identity.identifier%3Aeq%3ASENTINEL2A_20230604-105902-526_L2A_T31TCJ_D&righthand=false&pretty=false&flat=false&&&size=1&max-age-cache=120"
-        collection = "main_collection"
+        collection = COLLECTION
         catalog = "theia"
         inputs = InputIngestProcess(url=url, collection=collection, catalog=catalog)
         execute = Execute(inputs=inputs.model_dump())
@@ -87,7 +89,7 @@ class Tests(unittest.TestCase):
             sleep(1)
             status: StatusInfo = StatusInfo(**json.loads(requests.get("/".join([APROC_ENDPOINT, "jobs", status.jobID])).content))
         result = json.loads(requests.get("/".join([APROC_ENDPOINT, "jobs", status.jobID, "results"])).content)
-        self.assertEqual(result["item_location"], "http://airs-server:8000/arlas/airs/collections/main_collection/items/SENTINEL2A_20230604-105902-526_L2A_T31TCJ_D", result["item_location"])
+        self.assertEqual(result["item_location"], "http://airs-server:8000/arlas/airs/collections/"+COLLECTION+"/items/SENTINEL2A_20230604-105902-526_L2A_T31TCJ_D", result["item_location"])
 
     def test_get_jobs_by_resource_id(self):
         status: StatusInfo = self.__ingest_theia()

--- a/test/env.sh
+++ b/test/env.sh
@@ -29,14 +29,13 @@ export ARLAS_SMTP_FROM=noreply@arlas.io
 export APROC_DOWNLOAD_OUTBOX_DIR=/outbox
 export APROC_DOWNLOAD_ADMIN_EMAILS="admin@the.boss,someone.else@the.boss"
 
-export APROC_DOWNLOAD_CONTENT_USER="Download done."
-export APROC_DOWNLOAD_SUBJECT_USER="Download done."
+export APROC_DOWNLOAD_SUBJECT_USER="\"ARLAS Services: Your download of {collection}/{item_id}/{asset_name} is available.\""
+export APROC_DOWNLOAD_CONTENT_USER="\"ARLAS Services: Dear {arlas-user-email}. Your download of {collection}/{item_id}/{asset_name} is available for projection {target_projection} ({target_format}).ARLAS Services.\""
 
-export APROC_DOWNLOAD_CONTENT_ERROR="Download failed."
-export APROC_DOWNLOAD_SUBJECT_ERROR="Download failed."
+export APROC_DOWNLOAD_SUBJECT_ERROR="\"ARLAS Services: ERROR: The download of {collection}/{item_id}/{asset_name} failed ({error}).\""
+export APROC_DOWNLOAD_CONTENT_ERROR="\"ARLAS Services: The download of {collection}/{item_id}/{asset_name} failed ({error}).\""
 
-export APROC_DOWNLOAD_CONTENT_ADMIN="Download done."
-export APROC_DOWNLOAD_SUBJECT_ADMIN="Download done."
+export APROC_DOWNLOAD_SUBJECT_ADMIN="\"ARLAS Services: The download of {collection}/{item_id}/{asset_name} for {arlas-user-email} is available.\""
+export APROC_DOWNLOAD_CONTENT_ADMIN="\"ARLAS Services: The download of {collection}/{item_id}/{asset_name} for {arlas-user-email} is available in {target_directory} ({file_name}) for projection {target_projection} ({target_format}). ARLAS Services.\""
 
-#TODO add a function to identify the right platform
 export PLATFORM='amd64'

--- a/test/utils.py
+++ b/test/utils.py
@@ -34,9 +34,11 @@ def get_client():
 
 def setUpTest():
     import airs.core.product_registration as rs
+    print("Set up test environment")
     es = elasticsearch.Elasticsearch(index_endpoint_url)
     try:
         # Clean the index
+        print("delete {}".format(index_collection_prefix+"_"+COLLECTION))
         es.indices.delete(index=index_collection_prefix+"_"+COLLECTION)
     except Exception:
         ...


### PR DESCRIPTION
- add subject configuration in 
   - conf/download_drivers.yaml
   - extensions/aproc/proc/download/settings.py
   - test/env.sh
- refactor `execute` to better handle exceptions and error cases
- use parameter for the subject in extensions/aproc/proc/download/notifications.py
- update tests to test when the user requests a file that does not exist
- update the tests toi change the hard coded collection with the COLLECTION variable
