### PR TITLE
check match starts at 0

### DIFF
--- a/agate/rest/service.py
+++ b/agate/rest/service.py
@@ -30,20 +30,23 @@ async def path(request: Request):
         LOGGER.debug("test against {}".format(pattern))
         matches = re.finditer(pattern=pattern, string=requested_path)
         for match in matches:
-            LOGGER.debug("{} matches {}".format(requested_path, pattern))
-            try:
-                r = requests.get(Configuration.settings.arlas_url_search.format(collection=match.group("collection"), item=match.group("item")), headers=request.headers)
-                if r.ok:
-                    response = r.json()
-                    if response["hits"] is not None and len(response["hits"]) > 0:
-                        LOGGER.debug("ARLAS returned {} result(s) for {}".format(len(response["hits"]), requested_path))
-                        return Response(status_code=status.HTTP_202_ACCEPTED)
+            if match.start() == 0:
+                LOGGER.debug("{} matches {}".format(requested_path, pattern))
+                try:
+                    r = requests.get(Configuration.settings.arlas_url_search.format(collection=match.group("collection"), item=match.group("item")), headers=request.headers)
+                    if r.ok:
+                        response = r.json()
+                        if response["hits"] is not None and len(response["hits"]) > 0:
+                            LOGGER.debug("ARLAS returned {} result(s) for {}".format(len(response["hits"]), requested_path))
+                            return Response(status_code=status.HTTP_202_ACCEPTED)
+                        else:
+                            LOGGER.debug("ARLAS returned zero results for {}".format(requested_path))
                     else:
-                        LOGGER.debug("ARLAS returned zero results for {}".format(requested_path))
-                else:
-                    LOGGER.error("ARLAS failed to answer {}: {}".format(str(r.status_code), str(r.content)))
-                    return Response(status_code=r.status_code)
-            except Exception as e:
-                LOGGER.exception(e)
-                return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                        LOGGER.error("ARLAS failed to answer {}: {}".format(str(r.status_code), str(r.content)))
+                        return Response(status_code=r.status_code)
+                except Exception as e:
+                    LOGGER.exception(e)
+                    return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            else:
+                LOGGER.debug("Match not starting at the begining.")
     return Response(status_code=status.HTTP_403_FORBIDDEN)

--- a/test/agate_tests.py
+++ b/test/agate_tests.py
@@ -30,13 +30,16 @@ class Tests(unittest.TestCase):
 
     def test_access(self):
         # TEST OK for non public
-        r = requests.get(AGATE_ENDPOINT, headers={"X-Forwarded-Uri": "/"+"/".join(["minio", "collections", ARLAS_COLLECTION, "items", ID, "assets", ASSET])})
+        r = requests.get(AGATE_ENDPOINT, headers={"X-Forwarded-Uri": "/"+"/".join(["object", "collections", ARLAS_COLLECTION, "items", ID, "assets", ASSET])})
         self.assertTrue(r.ok, str(r.status_code)+" "+str(r.content))
+        # TEST KO for non public with wrong prefix
+        r = requests.get(AGATE_ENDPOINT, headers={"X-Forwarded-Uri": "/"+"/".join(["wrongprefix", "collections", ARLAS_COLLECTION, "items", ID, "assets", ASSET])})
+        self.assertFalse(r.ok, str(r.status_code)+" "+str(r.content))
         # TEST KO for non public
-        r = requests.get(AGATE_ENDPOINT,  headers={"X-Forwarded-Uri": "/"+"/".join(["minio", "collections", ARLAS_COLLECTION, "items", ID+"shouldnotwork", "assets", ASSET])})
+        r = requests.get(AGATE_ENDPOINT,  headers={"X-Forwarded-Uri": "/"+"/".join(["object", "collections", ARLAS_COLLECTION, "items", ID+"shouldnotwork", "assets", ASSET])})
         self.assertFalse(r.ok, str(r.status_code)+" "+str(r.content))
         # TEST OK for public
-        r = requests.get(AGATE_ENDPOINT, headers={"X-Forwarded-Uri": "/"+"/".join(["minio", "collections", ARLAS_COLLECTION, "items", ID+"shouldnotworkbutpublic", "assets", "thumbnail"])})
+        r = requests.get(AGATE_ENDPOINT, headers={"X-Forwarded-Uri": "/"+"/".join(["object", "collections", ARLAS_COLLECTION, "items", ID+"shouldnotworkbutpublic", "assets", "thumbnail"])})
         self.assertTrue(r.ok, str(r.status_code)+" "+str(r.content))
 
     def __add_item__(self) -> Item:


### PR DESCRIPTION
The matching was successful even in the middle of the url, so a check to verify that the start==0 was added in
agate/rest/service.py

Also a test has been added to check that a wrong prefix would fail in test/agate_tests.py