### PR TITLE
add cors for other http method

### DIFF
--- a/agate/cli/agate.py
+++ b/agate/cli/agate.py
@@ -1,18 +1,25 @@
 import typer
 import uvicorn
 from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware import Middleware
+import os
 
 from agate.rest.service import ROUTER
 from agate.settings import Configuration
 from common.exception_handler import EXCEPTION_HANDLERS
 
 cli = typer.Typer()
+AGATE_CORS = os.getenv("AGATE_CORS", "*")
 
 
 @cli.command(help="Start the ARLAS Asset Gateway.")
 def run(configuration_file: str = typer.Argument(..., help="Configuration file")):
     api = FastAPI(version='0.0', title='ARLAS Asset Gateway',
-                  description='ARLAS Asset Gateway API')
+                  description='ARLAS Asset Gateway API',
+                  middleware=[
+                    Middleware(CORSMiddleware, allow_origins=AGATE_CORS.split(","))
+                  ])
     Configuration.init(configuration_file)
     api.include_router(ROUTER, prefix=Configuration.settings.agate_prefix)
     for eh in EXCEPTION_HANDLERS:

--- a/airs/cli/airs.py
+++ b/airs/cli/airs.py
@@ -7,11 +7,14 @@ from fastapi import FastAPI
 from airs.core.settings import Configuration
 from airs.rest.services import ROUTER
 from common.exception_handler import EXCEPTION_HANDLERS
+from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware import Middleware
 
 cli = typer.Typer()
 AIRS_HOST = os.getenv("AIRS_HOST", "127.0.0.1")
 AIRS_PORT = os.getenv("AIRS_PORT", "8000")
 AIRS_PREFIX = os.getenv("AIRS_PREFIX", "/arlas/airs")
+AIRS_CORS = os.getenv("AIRS_CORS", "*")
 
 
 @cli.command(help="Start the ARLAS Item Registration Service.")
@@ -20,7 +23,10 @@ def run(configuration_file: str = typer.Argument(..., help="Configuration file")
         port: int = typer.Argument(default=AIRS_PORT, help="port")):
     Configuration.init(configuration_file=configuration_file)
     api = FastAPI(version='0.0', title='ARLAS Item Product Registration Service',
-                  description='ARLAS Item Registration Service API')
+                  description='ARLAS Item Registration Service API',
+                  middleware=[
+                    Middleware(CORSMiddleware, allow_origins=AIRS_CORS.split(","))
+                  ])
     api.include_router(ROUTER, prefix=AIRS_PREFIX)
     for eh in EXCEPTION_HANDLERS:
         api.add_exception_handler(eh.exception, eh.handler)

--- a/aproc/cli/aproc.py
+++ b/aproc/cli/aproc.py
@@ -3,6 +3,8 @@ import os
 import typer
 import uvicorn
 from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware import Middleware
 
 from aproc.service.aproc_services import AprocServices
 from common.exception_handler import EXCEPTION_HANDLERS
@@ -12,6 +14,7 @@ cli = typer.Typer()
 APROC_HOST = os.getenv("APROC_HOST", "127.0.0.1")
 APROC_PORT = os.getenv("APROC_PORT", "8001")
 APROC_PREFIX = os.getenv("APROC_PREFIX", "/arlas/aproc")
+APROC_CORS = os.getenv("APROC_CORS", "*")
 
 
 @cli.command(help="Start the ARLAS Processing Service.")
@@ -20,7 +23,10 @@ def run(
         port: int = typer.Argument(default=APROC_PORT, help="port")
         ):
     app = FastAPI(version='0.0', title='ARLAS Processes',
-                  description='ARLAS Processes')
+                  description='ARLAS Processes',
+                  middleware=[
+                    Middleware(CORSMiddleware, allow_origins=APROC_CORS.split(","))
+                  ])
     app.include_router(ROUTER, prefix=APROC_PREFIX)
     for eh in EXCEPTION_HANDLERS:
         app.add_exception_handler(eh.exception, eh.handler)

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -45,6 +45,7 @@ services:
     image: agate:latest
     container_name: 'agate'
     environment:
+      - AGATE_CORS=${AGATE_CORS:-*}
       - ARLAS_URL_SEARCH=$ARLAS_URL_SEARCH
       - AGATE_PREFIX=$AGATE_PREFIX
       - AGATE_HOST=$AGATE_HOST

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -134,6 +134,7 @@ services:
     environment:
       - AIRS_HOST=0.0.0.0
       - AIRS_PORT=8000
+      - AIRS_CORS=${AIRS_CORS:-*}
       - AIRS_INDEX_ENDPOINT_URL=${AIRS_INDEX_ENDPOINT_URL:-http://localhost:9200}
       - AIRS_INDEX_COLLECTION_PREFIX=${AIRS_INDEX_COLLECTION_PREFIX:-airs}
       - AIRS_INDEX_LOGIN=${AIRS_INDEX_LOGIN:-None}
@@ -167,6 +168,7 @@ services:
       - ARLAS_URL_SEARCH=$ARLAS_URL_SEARCH
       - APROC_HOST=0.0.0.0
       - APROC_PORT=8001
+      - APROC_CORS=${APROC_CORS:-*}
       - APROC_CONFIGURATION_FILE=/app/conf/aproc.yaml
       - CELERY_BROKER_URL=pyamqp://guest:guest@rabbitmq:5672//
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
@@ -231,6 +233,7 @@ services:
     environment:
       - INGESTED_FOLDER=/inputs
       - FAM_PREFIX=${FAM_PREFIX:-/arlas/fam}
+      - FAM_CORS=${FAM_CORS:-*}
     volumes:
       - ./test/inputs:/inputs:ro
     ports:

--- a/test/env.sh
+++ b/test/env.sh
@@ -4,6 +4,7 @@ export APROC_ENDPOINT=http://localhost:8001/arlas/aproc
 export ROOT_DIRECTORY=`pwd`/test/inputs
 
 # AIRS
+export AIRS_CORS="*"
 export AIRS_URL=http://airs-server:8000/arlas/airs
 export AIRS_ARLAS_COLLECTION_NAME=tests
 export AIRS_ARLAS_URL=http://localhost:81/server
@@ -22,8 +23,10 @@ export AIRS_LOGGER_LEVEL=DEBUG
 
 # APROC & AGATE
 export ARLAS_URL_SEARCH="http://arlas-server:9999/arlas/explore/{collection}/_search?f=id:eq:{item}"
+export AGATE_CORS="*"
 
 # APROC
+export APROC_CORS="*"
 export ARLAS_SMTP_ACTIVATED=true
 export ARLAS_SMTP_HOST=smtp4dev
 export ARLAS_SMTP_PORT=25
@@ -66,5 +69,5 @@ export AGATE_LOGGER_LEVEL=DEBUG
 # FAM
 export INGESTED_FOLDER=/inputs
 export FAM_LOGGER_LEVEL=DEBUG
-
+export FAM_CORS="*"
 export PLATFORM='amd64'


### PR DESCRIPTION
Add cors in the services:
- agate/cli/agate.py
- airs/cli/airs.py
- aproc/cli/aproc.py
- fam/cli/fam.py
Add variables in docker compose:
- docker-compose-tests.yaml
- docker-compose.yaml
- test/env.sh

Example of request with options:
`curl -X OPTIONS http://localhost:8005/arlas/fam/files -d '{"path":""}' --header "Content-Type:application/json"  -H 'Origin: http://example.com' -H 'Access-Control-Request-Method: GET' `