### PR TITLE
add healthchecks to microservices agate, airs aproc and fam

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ This stack relies on the docker compose configuration files. The available endpo
 - redis on port 6379
 - [SMTP4DEV](http://localhost:3000/) for email testing
 
+Health checks are available for all non-third party services:
+- [AIRS](http://localhost:8000/arlas/airs/healthcheck)
+- [APROC](http://localhost:8001/arlas/aproc/healthcheck)
+- [AGATE](http://localhost:8004/arlas/agate/healthcheck)
+- [FAM](http://localhost:8005/arlas/fam/healthcheck)
+
 
 # ARLAS Item Registration Services
 

--- a/agate/cli/agate.py
+++ b/agate/cli/agate.py
@@ -8,11 +8,12 @@ import os
 from agate.rest.service import ROUTER
 from agate.settings import Configuration
 from common.exception_handler import EXCEPTION_HANDLERS
-
+from common.healthcheck import ROUTER as HEALTHCHECK
 cli = typer.Typer()
 AGATE_CORS_ORIGINS = os.getenv("AGATE_CORS_ORIGINS", "*")
 AGATE_CORS_METHODS = os.getenv("AGATE_CORS_METHODS", "*")
 AGATE_CORS_HEADERS = os.getenv("AGATE_CORS_HEADERS", "*")
+
 
 @cli.command(help="Start the ARLAS Asset Gateway.")
 def run(configuration_file: str = typer.Argument(..., help="Configuration file")):
@@ -24,6 +25,7 @@ def run(configuration_file: str = typer.Argument(..., help="Configuration file")
                               ])
     Configuration.init(configuration_file)
     api.include_router(ROUTER, prefix=Configuration.settings.agate_prefix)
+    api.include_router(HEALTHCHECK, prefix=Configuration.settings.agate_prefix)
     for eh in EXCEPTION_HANDLERS:
         api.add_exception_handler(eh.exception, eh.handler)
     uvicorn.run(api, host=Configuration.settings.host, port=Configuration.settings.port)

--- a/airs/cli/airs.py
+++ b/airs/cli/airs.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from airs.core.settings import Configuration
 from airs.rest.services import ROUTER
 from common.exception_handler import EXCEPTION_HANDLERS
+from common.healthcheck import ROUTER as HEALTHCHECK
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware import Middleware
 
@@ -31,6 +32,7 @@ def run(configuration_file: str = typer.Argument(..., help="Configuration file")
                                          allow_headers=AIRS_CORS_HEADERS.split(","))
                               ])
     api.include_router(ROUTER, prefix=AIRS_PREFIX)
+    api.include_router(HEALTHCHECK, prefix=AIRS_PREFIX)
     for eh in EXCEPTION_HANDLERS:
         api.add_exception_handler(eh.exception, eh.handler)
     uvicorn.run(api, host=host, port=port)

--- a/aproc/cli/aproc.py
+++ b/aproc/cli/aproc.py
@@ -8,6 +8,7 @@ from starlette.middleware import Middleware
 
 from aproc.service.aproc_services import AprocServices
 from common.exception_handler import EXCEPTION_HANDLERS
+from common.healthcheck import ROUTER as HEALTHCHECK
 from aproc.service.ogc_processes_api import ROUTER
 
 cli = typer.Typer()
@@ -24,18 +25,19 @@ def run(
         host: str = typer.Argument(default=APROC_HOST, help="host"),
         port: int = typer.Argument(default=APROC_PORT, help="port")
         ):
-    app = FastAPI(version='0.0', title='ARLAS Processes',
+    api = FastAPI(version='0.0', title='ARLAS Processes',
                   description='ARLAS Processes',
                   middleware=[Middleware(CORSMiddleware, allow_origins=APROC_CORS_ORIGINS.split(","),
                                          allow_methods=APROC_CORS_METHODS.split(","),
                                          allow_headers=APROC_CORS_HEADERS.split(","))
                               ])
-    app.include_router(ROUTER, prefix=APROC_PREFIX)
+    api.include_router(ROUTER, prefix=APROC_PREFIX)
+    api.include_router(HEALTHCHECK, prefix=APROC_PREFIX)
     for eh in EXCEPTION_HANDLERS:
-        app.add_exception_handler(eh.exception, eh.handler)
+        api.add_exception_handler(eh.exception, eh.handler)
 
     AprocServices.init()
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(api, host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/common/healthcheck.py
+++ b/common/healthcheck.py
@@ -1,0 +1,10 @@
+
+from fastapi import APIRouter, status
+from fastapi.responses import Response
+
+ROUTER = APIRouter()
+
+
+@ROUTER.get("/healthcheck")
+async def healthcheck():
+    return Response(content="OK", status_code=status.HTTP_200_OK)

--- a/fam/cli/fam.py
+++ b/fam/cli/fam.py
@@ -7,6 +7,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware import Middleware
 
 from common.exception_handler import EXCEPTION_HANDLERS
+from common.healthcheck import ROUTER as HEALTHCHECK
 from extensions.aproc.proc.ingest.drivers.drivers import Drivers
 from fam.core.settings import Configuration
 from fam.rest.services import ROUTER
@@ -18,6 +19,7 @@ FAM_PREFIX = os.getenv("FAM_PREFIX", "/arlas/fam")
 FAM_CORS_ORIGINS = os.getenv("FAM_CORS_ORIGINS", "*")
 FAM_CORS_METHODS = os.getenv("FAM_CORS_METHODS", "*")
 FAM_CORS_HEADERS = os.getenv("FAM_CORS_HEADERS", "*")
+
 
 @cli.command(help="Start the File and Archive Management Service.")
 def run(configuration_file: str = typer.Argument(..., help="Configuration file"),
@@ -32,9 +34,11 @@ def run(configuration_file: str = typer.Argument(..., help="Configuration file")
                                          allow_headers=FAM_CORS_HEADERS.split(","))
                               ])
     api.include_router(ROUTER, prefix=FAM_PREFIX)
+    api.include_router(HEALTHCHECK, prefix=FAM_PREFIX)
 #    for eh in EXCEPTION_HANDLERS:
 #        api.add_exception_handler(eh.exception, eh.handler)
     uvicorn.run(api, host=host, port=port)
+
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
Add healthcheck to microservices
Implementation is provided in common/healthcheck.py
Health checks are available for all non-third party services:
- [AIRS](http://localhost:8000/arlas/airs/healthcheck)
- [APROC](http://localhost:8001/arlas/aproc/healthcheck)
- [AGATE](http://localhost:8004/arlas/agate/healthcheck)
- [FAM](http://localhost:8005/arlas/fam/healthcheck)
