### PR TITLE
add total hits and filter on process id

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,33 +452,34 @@ Result:
 ]
 ```
 
-To get the status of the most recent processes (the service offers pages):
+To get the status of the most recent processes for ingest and which are running:
 
 ```shell
 curl -X 'GET' \
-  'http://localhost:8001/arlas/aproc/jobs?page=0&page_size=10' \
+  'http://localhost:8001/arlas/aproc/jobs?offset=0&limit=10&process_id=ingest&status=running' \
   -H 'accept: application/json'
 ```
 Result:
 ```json
-[
-  {
-    "processID": "download",
-    "type": "process",
-    "jobID": "40154302-4ca7-468c-854d-c09b245e3e64",
-    "status": "successful",
-    "message": "{'download_location': '/outbox/anonymous/inputs-DIMAP-PROD_SPOT6_001-VOL_SPOT6_001_A-IMG_SPOT6_MS_001_A/inputs_DIMAP_PROD_SPOT6_001_VOL_SPOT6_001_A_IMG_SPOT6_MS_001_A.Geotiff'}",
-    "created": 1698154319,
-    "started": 1698154319,
-    "finished": 1698154440,
-    "updated": 1698154440,
-    "progress": null,
-    "links": null,
-    "resourceID": "db6bd405d357b8f6420bfe6797bbbec1e6430afe"
-  }, ...
-]
+{
+    "status_list": [
+        {
+            "processID": "ingest",
+            "type": "process",
+            "jobID": "c8c79f8e-51c9-4a99-96e2-527cc365cb1d",
+            "status": "successful",
+            "message": "{'item_location': 'http://airs-server:8000/arlas/airs/collections/digitalearth.africa/items/SENTINEL2A_20230604-105902-526_L2A_T31TCJ_D'}",
+            "created": 1698400307,
+            "started": 1698400320,
+            "finished": 1698400327,
+            "updated": 1698400327,
+            "resourceID": "SENTINEL2A_20230604-105902-526_L2A_T31TCJ_D"
+        },
+        ...
+    ],
+    "total": 41
+}
 ```
-
 
 
 ## AGATE

--- a/aproc/core/models/ogc/job.py
+++ b/aproc/core/models/ogc/job.py
@@ -24,3 +24,11 @@ class StatusInfo(BaseModel):
 
     # This field is specific to airs : it stores the resource id that is the input of a process
     resourceID: str | None = Field(default=None)
+
+
+class StatusInfoList(BaseModel):
+    class Config:
+        extra = Extra.allow
+
+    status_list: list[StatusInfo] | None = Field(default=None)
+    total: int | None = Field(default=None)

--- a/aproc/service/ogc_processes_api.py
+++ b/aproc/service/ogc_processes_api.py
@@ -7,6 +7,7 @@ from aproc.core.models.ogc import (Conforms, ExceptionType, Execute,
                                    InlineOrRefData, LandingPage, Link,
                                    ProcessDescription, ProcessList,
                                    ProcessSummary, StatusInfo)
+from aproc.core.models.ogc.job import StatusInfoList
 from aproc.core.processes.exception import ProcessException
 from aproc.core.processes.process import Process
 from aproc.core.processes.processes import Processes
@@ -34,9 +35,10 @@ def get_conformance() -> Conforms:
 
 
 @ROUTER.get("/jobs",
-            response_model_exclude_none=True)
-def get_jobs(page: int = 0, page_size: int = 10):
-    return Processes.list_jobs(page=page, page_size=page_size)
+            response_model_exclude_none=True,
+            response_model=StatusInfoList)
+def get_jobs(offset: int = 0, limit: int = 10, process_id: str = None, status: str = None):
+    return Processes.list_jobs(offset=offset, limit=limit, process_id=process_id, status=status)
 
 @ROUTER.get("/jobs/{jobId}",
             response_model_exclude_none=True,

--- a/extensions/aproc/proc/download/notifications.py
+++ b/extensions/aproc/proc/download/notifications.py
@@ -62,7 +62,7 @@ class Notifications:
                     Notifications.__getES().indices.create(index=Configuration.settings.index_for_download.index_name, mappings=mapping)
                     LOGGER.info("Mapping {} updated.".format(Configuration.settings.index_for_download.index_name))
                 else:
-                    LOGGER.info("Index {} found.".format(Configuration.settings.index_for_download.index_name))
+                    LOGGER.debug("Index {} found.".format(Configuration.settings.index_for_download.index_name))
 
                 Notifications.__getES().index(
                     index=Configuration.settings.index_for_download.index_name,

--- a/extensions/aproc/proc/ingest/directory_ingest_process.py
+++ b/extensions/aproc/proc/ingest/directory_ingest_process.py
@@ -96,13 +96,16 @@ class AprocProcess(Process):
                 execute = Execute(inputs=inputs.model_dump())
                 r = requests.post("/".join([Configuration.settings.aproc_endpoint, "processes", "ingest", "execution"]), data=json.dumps(execute.model_dump()), headers=headers)
                 if not r.ok:
-                    LOGGER.error("Failed to submit the ingest request for {} ({}): {}".format(archive.path, archive.id, str(r.status_code)+":"+r.content))
+                    msg = "Failed to submit the ingest request for {} ({}): {}".format(archive.path, archive.id, str(r.status_code) + ":" + r.content)
+                    LOGGER.error(msg)
+                    raise Exception(msg)
                 else:
-                    LOGGER.info("Send ingestion request for {} ({})".format(archive.path, archive.id))
+                    LOGGER.debug("Send ingestion request for {} ({}) ok".format(archive.path, archive.id))
             except Exception as e:
                 msg = "Failed to submit the ingest request for {} ({}): {}".format(archive.path, archive.id, e.__cause__)
                 LOGGER.error(msg)
                 LOGGER.exception(e)
+                raise Exception(msg)
         return list(map(lambda a: a.model_dump(), archives))
 
     def list_archives(prefix: str, path: str, size: int = 0, max_size: int = 10) -> list[Archive]:

--- a/test/aproc_ingest_heavyload_tests.py
+++ b/test/aproc_ingest_heavyload_tests.py
@@ -19,7 +19,7 @@ class Tests(unittest.TestCase):
 
     def setUp(self):
         setUpTest()
-        if not os.path.exists(THEIA_DIR):
+        if not os.path.exists(os.path.join("test", THEIA_DIR)):
             with open("test/inputs/template_theia.json") as json_file:
                 d = json.load(json_file)
                 id = d["hits"][0]["md"]["id"]

--- a/test/fam_tests.py
+++ b/test/fam_tests.py
@@ -37,10 +37,11 @@ class Tests(unittest.TestCase):
         r = requests.post(url=os.path.join(FAM_URL, "archives"), data=PathRequest(path=root.path + "/DIMAP").model_dump_json(), headers={"Content-Type": "application/json"})
         self.assertTrue(r.ok)
         archive = Archive(**(json.loads(r.content)[0]))
+        print(archive.model_dump_json())
         self.assertEquals(archive.name, "IMG_SPOT6_MS_001_A")
         self.assertEquals(archive.path, root.path + "/DIMAP/PROD_SPOT6_001/VOL_SPOT6_001_A/IMG_SPOT6_MS_001_A")
         self.assertEquals(archive.is_dir, True)
-        self.assertEquals(archive.id, "inputs-DIMAP-PROD_SPOT6_001-VOL_SPOT6_001_A-IMG_SPOT6_MS_001_A")
+        self.assertEquals(archive.id, "SPOT6_MS_202308241027346_SEN_SPOT6_20230904_0941551hqi8awn5jlpu_1")
         self.assertEquals(archive.driver_name, "dimap")
 
 


### PR DESCRIPTION
- change status api (aproc/service/ogc_processes_api.py)
   - for more suitable parameters (page&page_size -> offset&limit)
   - add filter on status
   - add filter on process_id
   - return list and size : `{"status_list": [ ... ], "total": 41}`
      - add warping class for result: aproc/core/models/ogc/job.py (`StatusInfoList`)
- implement in aproc/core/processes/processes.py
- update tests test/aproc_ingest_heavyload_tests.py

Side change:
- move info to debug for index found in notifications (extensions/aproc/proc/download/notifications.py)
- move info to debug for ingest request submitted (extensions/aproc/proc/ingest/directory_ingest_process.py)
- update test for FAM that was not working due to resource id changes (test/fam_tests.py)