### PR TITLE
Bug/#152 Add tests to check that main_asset_format, main_asset_name and proj__epsg are provided.

### DIFF
--- a/test/aproc_ingest_tests.py
+++ b/test/aproc_ingest_tests.py
@@ -144,9 +144,9 @@ class Tests(unittest.TestCase):
             self.assertIsNotNone(item.properties.sensor)
             self.assertIsNotNone(item.properties.sensor_type)
             self.assertIsNotNone(item.properties.gsd)
-            self.assertIsNotNone(item.properties.main_asset_format)
-            self.assertIsNotNone(item.properties.main_asset_name)
-            self.assertIsNotNone(item.properties.proj__epsg)
+        self.assertIsNotNone(item.properties.main_asset_format)
+        self.assertIsNotNone(item.properties.main_asset_name)
+        self.assertIsNotNone(item.properties.proj__epsg)
 
     def test_job_by_id(self):
         url = "/inputs/DIMAP/PROD_SPOT6_001/VOL_SPOT6_001_A/IMG_SPOT6_MS_001_A/"


### PR DESCRIPTION
Fix #152: Add tests to check that `main_asset_format`, `main_asset_name` and `proj__epsg` are provided, also when not in an archive.
