### PR TITLE
add data to dimap when jp2

### DIFF
--- a/extensions/aproc/proc/ingest/drivers/impl/dimap.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/dimap.py
@@ -234,14 +234,17 @@ class Driver(ProcDriver):
                         Driver.dim_path = os.path.join(path, file)
                     if file.endswith('.JPG') and file.startswith('PREVIEW'):
                         raw_all_quick_path = os.path.join(path, file)
-                    if file.lower().endswith('.jpg') and file.startswith('IMG_'):
+
+                    # Data and georef
+                    if file.lower().endswith(('.jpg', 'jp2')) and file.startswith('IMG_'):
                         Driver.image_path = os.path.join(path, file)
                     if file.lower().endswith('.tfw') and file.startswith('IMG_'):
                         Driver.georef_path = os.path.join(path, file)
                     if file.lower().endswith('.j2w') and file.startswith('IMG_'):
                         Driver.georef_path = os.path.join(path, file)
-                    if (file.lower().endswith('.tiff') or file.lower().endswith('.tif')) and file.startswith('IMG_'):
+                    if file.lower().endswith(('.tiff', '.tif')) and file.startswith('IMG_'):
                         Driver.image_path = os.path.join(path, file)
+
                     if file.endswith('.JPG') and file.startswith('ICON'):
                         raw_all_thumb_path = os.path.join(path, file)
                     if file.endswith('.JPG') and file.startswith('CAT_QL'):

--- a/test/aproc_ingest_tests.py
+++ b/test/aproc_ingest_tests.py
@@ -6,7 +6,7 @@ from time import sleep
 import requests
 
 from airs.core.models import mapper
-from airs.core.models.model import Item
+from airs.core.models.model import Item, Asset, Role
 from aproc.core.models.ogc import Execute
 from aproc.core.models.ogc.job import StatusCode, StatusInfo
 from aproc.core.models.ogc.process import ProcessDescription, ProcessList
@@ -126,6 +126,7 @@ class Tests(unittest.TestCase):
         self.assertIsNotNone(item.geometry.get("coordinates"))
         self.assertEquals(len(item.bbox), 4)
         self.assertEquals(len(item.centroid), 2)
+        self.assertIn(Role.data.value, item.assets.keys())
         for asset in assets:
             self.assertIsNotNone(item.assets.get(asset), asset)
             self.assertIsNotNone(item.assets.get(asset).name, asset)
@@ -147,6 +148,7 @@ class Tests(unittest.TestCase):
         self.assertIsNotNone(item.properties.main_asset_format)
         self.assertIsNotNone(item.properties.main_asset_name)
         self.assertIsNotNone(item.properties.proj__epsg)
+        print(mapper.to_json(item))
 
     def test_job_by_id(self):
         url = "/inputs/DIMAP/PROD_SPOT6_001/VOL_SPOT6_001_A/IMG_SPOT6_MS_001_A/"


### PR DESCRIPTION
When data contains jp2, it is not recognized as the main data.
This fix this. The remaining problem is : what do we do if more than one data file?
Current implementation keeps the last one.