### PR TITLE
fix driver spot5 and dimap and no overview

### DIFF
--- a/extensions/aproc/proc/ingest/drivers/impl/dimap.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/dimap.py
@@ -170,7 +170,10 @@ class Driver(ProcDriver):
                     cloud_cover = float(cloud.find("CLOUD_COVERAGE").text)
 
         # We calculate the GSD as the mean of  GSD_ACROSS_TRACK and  GSD_ALONG_TRACK
-        gsd = (float(metadata["GSD_ACROSS_TRACK"]) + float(metadata["GSD_ALONG_TRACK"])) / 2
+        if metadata.get("GSD_ACROSS_TRACK") and metadata.get("GSD_ALONG_TRACK"):
+            gsd = (float(metadata["GSD_ACROSS_TRACK"]) + float(metadata["GSD_ALONG_TRACK"])) / 2
+        else:
+            gsd = None
         item = Item(
             id=self.get_item_id(url),
             geometry=geometry,
@@ -178,14 +181,14 @@ class Driver(ProcDriver):
             centroid=centroid,
             properties=Properties(
                 datetime=date_time,
-                processing__level=metadata["PROCESSING_LEVEL"],
+                processing__level=metadata.get("PROCESSING_LEVEL"),
                 eo__cloud_cover=cloud_cover,
                 gsd=gsd,
                 proj__epsg=get_epsg(src_ds),
-                view__incidence_angle=metadata["INCIDENCE_ANGLE"],
-                view__azimuth=metadata["AZIMUTH_ANGLE"],
-                view__sun_azimuth=metadata["SUN_AZIMUTH"],
-                view__sun_elevation=metadata["SUN_ELEVATION"],
+                view__incidence_angle=metadata.get("INCIDENCE_ANGLE"),
+                view__azimuth=metadata.get("AZIMUTH_ANGLE"),
+                view__sun_azimuth=metadata.get("SUN_AZIMUTH"),
+                view__sun_elevation=metadata.get("SUN_ELEVATION"),
                 item_type=ResourceType.gridded.value,
                 item_format=ItemFormat.dimap.value,
                 main_asset_format=self.get_main_asset_format(root),

--- a/extensions/aproc/proc/ingest/drivers/impl/image_driver_helper.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/image_driver_helper.py
@@ -43,6 +43,7 @@ class ImageDriverHelper:
             image.save(asset.href, 'PNG')
             asset.size = get_file_size(asset.href)
             to_assets.append(asset)
+            image.close()
         except Exception as e:
             driver.LOGGER.warn("Couldn't create the thumbnail of {}".format(url))
             driver.LOGGER.error(e)

--- a/extensions/aproc/proc/ingest/drivers/impl/spot5.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/spot5.py
@@ -79,7 +79,10 @@ class Driver(ProcDriver):
             coords.append(coord)
         geometry, bbox, centroid = get_geom_bbox_centroid(coords[0][0], coords[0][1], coords[1][0], coords[1][1],
                                                           coords[2][0], coords[2][1], coords[3][0], coords[3][1])
-        gsd = (float(root.find('./Geoposition/Geoposition_Insert/XDIM').text) + float(root.find('./Geoposition/Geoposition_Insert/YDIM').text))/2
+        if root.find('./Geoposition/Geoposition_Insert/XDIM') and root.find('./Geoposition/Geoposition_Insert/YDIM'):
+            gsd = (float(root.find('./Geoposition/Geoposition_Insert/XDIM').text) + float(root.find('./Geoposition/Geoposition_Insert/YDIM').text))/2
+        else:
+            gsd = None
         src_ds = gdal.Open(self.dim_path, GA_ReadOnly)
         metadata = src_ds.GetMetadata()
         # We retrieve the time
@@ -93,16 +96,16 @@ class Driver(ProcDriver):
             centroid=centroid,
             properties=Properties(
                 datetime=date_time,
-                processing__level=metadata["PROCESSING_LEVEL"],
+                processing__level=metadata.get("PROCESSING_LEVEL"),
                 gsd=gsd,
                 proj__epsg=get_epsg(src_ds),
-                instrument= metadata["INSTRUMENT"],
-                constellation = metadata["MISSION"],
-                sensor = metadata["MISSION"],
-                sensor_type = metadata["MISSION_INDEX"],
-                view__incidence_angle=metadata["INCIDENCE_ANGLE"],
-                view__sun_azimuth= metadata["SUN_AZIMUTH"],
-                view__sun_elevation= metadata["SUN_ELEVATION"],
+                instrument=metadata.get("INSTRUMENT"),
+                constellation=metadata.get("MISSION"),
+                sensor=metadata.get("MISSION"),
+                sensor_type=metadata.get("MISSION_INDEX"),
+                view__incidence_angle=metadata.get("INCIDENCE_ANGLE"),
+                view__sun_azimuth=metadata.get("SUN_AZIMUTH"),
+                view__sun_elevation=metadata.get("SUN_ELEVATION"),
                 item_type=ResourceType.gridded.value,
                 item_format=ItemFormat.spot5.value,
                 main_asset_format=AssetFormat.geotiff.value,

--- a/extensions/aproc/proc/ingest/drivers/impl/tiff.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/tiff.py
@@ -26,7 +26,8 @@ class Driver(ProcDriver):
 
     # Implements drivers method
     def fetch_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
-        return ImageDriverHelper.fetch_assets(self, url, assets)
+        # return ImageDriverHelper.fetch_assets(self, url, assets)
+        return assets
 
     # Implements drivers method
     def get_item_id(self, url: str) -> str:


### PR DESCRIPTION
- remove generation of overviews for tiff (all black)
- make spot5 and dimap more robust to missing fields