### PR TITLE
Add url pattern matching for titiler in agate

### DIFF
--- a/agate/rest/service.py
+++ b/agate/rest/service.py
@@ -6,41 +6,82 @@ from fastapi import APIRouter, Request, status
 from fastapi.responses import Response
 
 from agate.logger import Logger
-from agate.settings import Configuration
+from agate.settings import Configuration, Service
+from urllib import parse
 
 LOGGER = Logger.logger
 ROUTER = APIRouter()
 
 
-@ROUTER.get("/authorization")
-async def path(request: Request):
-    requested_path = request.headers[Configuration.settings.url_header]
+@ROUTER.get("/authorization/{service}")
+async def path(request: Request, service: str):
+    service: Service = Configuration.settings.services.get(service)
+    if not service:
+        msg = "Service {} not found".format(service)
+        LOGGER.error(msg)
+        return Response(status_code=status.HTTP_404_NOT_FOUND, content=msg)
+    requested_path = request.headers[service.url_header]
     LOGGER.debug("Incoming URI: {}".format(requested_path))
-    if not not Configuration.settings.url_header_prefix:
-        requested_path = requested_path.removeprefix(Configuration.settings.url_header_prefix)
-    LOGGER.debug("URI for matching: {}".format(requested_path))
-    patterns = Configuration.settings.url_patterns
-    public_patterns = Configuration.settings.public_url_patterns
-    for pattern in public_patterns:
-        LOGGER.debug("test against public pattern {}".format(pattern))
-        matches = re.finditer(pattern=pattern, string=requested_path)
-        for match in matches:
-            return Response(status_code=status.HTTP_202_ACCEPTED)
+    if service.pattern_target:
+        LOGGER.debug("Using {} for computing the target".format(service.pattern_target))
+        if service.pattern_target.startswith("query."):
+            param_name = service.pattern_target.split(".")[1]
+            LOGGER.debug("Using query parameter {} as target".format(param_name))
+            query = parse.urlparse(requested_path).query
+            param = parse.parse_qs(query).get(param_name)
+            if param is None or len(param) < 1:
+                msg = "Parameter {} not found in query {} for service {}".format(param_name, query, service)
+                LOGGER.error(msg)
+                return Response(status_code=status.HTTP_404_NOT_FOUND, content=msg)
+            else:
+                param = param[0]
+            LOGGER.debug("{}={}".format(param_name, param))
+            if service.pattern_target.endswith(".path") or service.pattern_target.endswith(".query"):
+                url: parse.ParseResult = parse.urlparse(param)
+                if service.pattern_target.endswith(".url.path"):
+                    LOGGER.debug("Using path of url {} as target".format(param))
+                    target = url.path
+                elif service.pattern_target.endswith(".url.query"):
+                    LOGGER.debug("Using query of url {} as target".format(param))
+                    target = url.query
+            else:
+                LOGGER.debug("Using query parameter {} as target".format(param_name))
+                target = parse.urlparse(requested_path).query
+        else:
+            msg = "Invalid configuration '{}' for pattern_target of {}".format(service.pattern_target, service)
+            LOGGER.error(msg)
+            return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content=msg)
+    else:
+        LOGGER.debug("Using path as target")
+        target = requested_path
+    if service.url_header_prefix:
+        target = target.removeprefix(service.url_header_prefix)
+    LOGGER.debug("Pattern matching on: {}".format(target))
+    patterns = service.url_patterns
+    public_patterns = service.public_url_patterns
+    if public_patterns:
+        for pattern in public_patterns:
+            LOGGER.debug("test against public pattern {}".format(pattern))
+            matches = re.finditer(pattern=pattern, string=target)
+            for match in matches:
+                return Response(status_code=status.HTTP_202_ACCEPTED)
+    if not patterns:
+        return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content="Invalid configuration: not pattern configured for {}".format(service))
     for pattern in patterns:
         LOGGER.debug("test against {}".format(pattern))
-        matches = re.finditer(pattern=pattern, string=requested_path)
+        matches = re.finditer(pattern=pattern, string=target)
         for match in matches:
             if match.start() == 0:
-                LOGGER.debug("{} matches {}".format(requested_path, pattern))
+                LOGGER.debug("{} matches {}".format(target, pattern))
                 try:
                     r = requests.get(Configuration.settings.arlas_url_search.format(collection=match.group("collection"), item=match.group("item")), headers={"authorization": request.headers.get("authorization"), "arlas-org-filter": request.headers.get("arlas-org-filter")})
                     if r.ok:
                         response = r.json()
                         if response["hits"] is not None and len(response["hits"]) > 0:
-                            LOGGER.debug("ARLAS returned {} result(s) for {}".format(len(response["hits"]), requested_path))
+                            LOGGER.debug("ARLAS returned {} result(s) for {}".format(len(response["hits"]), target))
                             return Response(status_code=status.HTTP_202_ACCEPTED)
                         else:
-                            LOGGER.debug("ARLAS returned zero results for {}".format(requested_path))
+                            LOGGER.debug("ARLAS returned zero results for {}".format(target))
                     else:
                         LOGGER.error("ARLAS failed to answer {}: {}".format(str(r.status_code), str(r.content)))
                         return Response(status_code=r.status_code)

--- a/agate/settings.py
+++ b/agate/settings.py
@@ -10,7 +10,7 @@ class Service(BaseModel, extra=Extra.allow):
     public_url_patterns: list[str] | None
     url_header: str
     url_header_prefix: str | None
-    pattern_target: str | None = Field(title="If undefined, then the pattern is matched against the path. User query.{param}, where {param} is the parameter value, to use a query parameter. Use query.{param}.url.path|query if the param value is a url and that you want to target the path or query of that url.")
+    pattern_target: str | None = Field(title="If undefined, then the pattern is matched against the path. Use query.{param}, where {param} is the parameter value, to use a query parameter. Use query.{param}.url.path|query if the param value is a url and that you want to target the path or query of that url.")
 
 
 class Settings(BaseModel, extra=Extra.allow):
@@ -18,7 +18,7 @@ class Settings(BaseModel, extra=Extra.allow):
     agate_prefix: str
     host: str
     port: int
-    services: dict[str, Service] = Field({}, title="dictionary of service name/values. Each value is a pattern configuration for extracting collection and id values for building an ARLAS request that determines whether the access is granted or not.")
+    services: dict[str, Service] = Field({}, title="Dictionary of service name/values. Each value is a pattern configuration for extracting collection and id values for building an ARLAS request that determines whether the access is granted or not.")
 
 
 class Configuration:

--- a/agate/settings.py
+++ b/agate/settings.py
@@ -5,15 +5,21 @@ from agate.logger import Logger
 LOGGER = Logger.logger
 
 
+class Service(BaseModel, extra=Extra.allow):
+    url_patterns: list[str]
+    public_url_patterns: list[str] | None
+    url_header: str
+    url_header_prefix: str | None
+    pattern_target: str | None = Field(title="If undefined, then the pattern is matched against the path. User query.{param}, where {param} is the parameter value, to use a query parameter. Use query.{param}.url.path|query if the param value is a url and that you want to target the path or query of that url.")
+
+
 class Settings(BaseModel, extra=Extra.allow):
     arlas_url_search: str = Field(title="ARLAS URL Search (ex http://arlas-server:9999/arlas/explore/{collection}/_search?f=id:eq:{item})")
     agate_prefix: str
     host: str
     port: int
-    url_patterns: list[str]
-    public_url_patterns: list[str]
-    url_header: str
-    url_header_prefix: str
+    services: dict[str, Service] = Field({}, title="dictionary of service name/values. Each value is a pattern configuration for extracting collection and id values for building an ARLAS request that determines whether the access is granted or not.")
+
 
 class Configuration:
     settings: Settings = None

--- a/conf/agate.yaml
+++ b/conf/agate.yaml
@@ -1,11 +1,20 @@
-
 arlas_url_search: $ARLAS_URL_SEARCH|http://arlas-server:9999/arlas/explore/{collection}/_search?f=id:eq:{item}
 agate_prefix: $AGATE_PREFIX|/arlas/agate
 host: $AGATE_HOST|127.0.0.1
 port: $AGATE_PORT|8004
-url_patterns:
-  - $ASSET_MINIO_PATTERN|(/collections/)(?P<collection>[^/]+)/items/(?P<item>[^/]+)/assets/(?P<asset>[^/]+)
-public_url_patterns: 
-  - $ASSET_MINIO_PUBLIC_PATTERN|(/collections/)(?P<collection>[^/]+)/items/(?P<item>[^/]+)/assets/thumbnail
-url_header: $AGATE_URL_HEADER|X-Forwarded-Uri
-url_header_prefix: $AGATE_URL_HEADER_PREFIX
+services:
+  airs:
+    url_patterns:
+      - $ASSET_MINIO_PATTERN|(/collections/)(?P<collection>[^/]+)/items/(?P<item>[^/]+)/assets/(?P<asset>[^/]+)
+    public_url_patterns: 
+      - $ASSET_MINIO_PUBLIC_PATTERN|(/collections/)(?P<collection>[^/]+)/items/(?P<item>[^/]+)/assets/thumbnail
+    url_header: $AGATE_URL_HEADER|X-Forwarded-Uri
+    url_header_prefix: $AGATE_URL_HEADER_PREFIX
+    pattern_target:
+  titiler:
+    url_patterns:
+      - $TITILER_PATTERN|(/collections/)(?P<collection>[^/]+)/items/(?P<item>[^/]+)/assets/(?P<asset>[^/]+)
+    public_url_patterns: 
+    url_header: $AGATE_URL_HEADER|X-Forwarded-Uri
+    url_header_prefix: $AGATE_URL_HEADER_PREFIX
+    pattern_target: $TITILER_PATTERN_TARGET|query.url.url.path # takes the query parametters, use it as a url, then extract the path


### PR DESCRIPTION
**Description of the issue**
Agate is a forward auth service for apisix. It receives a request from apisix and extracts
- the collection name
- the item id
- the user identity
and builds a request to arlas server to see if the user can see the item id within the collection.
Before, it was able to extract the collection name and id from the URL path, thanks to a pattern like:
`https://myservice/airstorage/collections/<collection>/items/<item>/assets/<asset>`

With the integration of titiler for visualizing the COGs, it is necessary to extract the collection name and id differently because the url is like:
`https://myservice/titiler/cog?url=https://myservice/airstorage/collections/<collection>/items/<item>/assets/<asset>` 

As a result, changes have been done to:
- manage different configuration (one per service), for instance one for airs storage (thumbnails and overview), one for COGs
- Extract the url within the query

Tests have been added to check the changes.