### PR TITLE
use driver object instead of class

### DIFF
--- a/extensions/aproc/proc/download/drivers/download_driver.py
+++ b/extensions/aproc/proc/download/drivers/download_driver.py
@@ -7,13 +7,14 @@ from extensions.aproc.proc.drivers.abstract_driver import AbstractDriver
 class DownloadDriver(AbstractDriver):
     """ Driver for exporting files for download
     """
+    alternative_asset_href_field: str = None
 
     def __init__(self):
         super().__init__()
-        self.alternative_asset_href_field: str = None
 
-    def init(self, configuration: dict) -> None:
-        self.alternative_asset_href_field = configuration.get("alternative_asset_href_field")
+    def init(configuration: dict) -> None:
+        if configuration:
+            DownloadDriver.alternative_asset_href_field = configuration.get("alternative_asset_href_field")
 
     def get_asset_href(self, item: Item) -> str | None:
         if self.alternative_asset_href_field:

--- a/extensions/aproc/proc/download/drivers/impl/image_file.py
+++ b/extensions/aproc/proc/download/drivers/impl/image_file.py
@@ -12,8 +12,8 @@ class Driver(DownloadDriver):
         super().__init__()
 
     # Implements drivers method
-    def init(self, configuration: dict):
-        ...
+    def init(configuration: dict):
+        DownloadDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, item: Item) -> bool:

--- a/extensions/aproc/proc/download/drivers/impl/met_file.py
+++ b/extensions/aproc/proc/download/drivers/impl/met_file.py
@@ -13,8 +13,8 @@ class Driver(DownloadDriver):
         super().__init__()
 
     # Implements drivers method
-    def init(self, configuration: dict):
-        ...
+    def init(configuration: dict):
+        DownloadDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, item: Item) -> bool:

--- a/extensions/aproc/proc/download/drivers/impl/simple_copy.py
+++ b/extensions/aproc/proc/download/drivers/impl/simple_copy.py
@@ -14,8 +14,8 @@ class Driver(DownloadDriver):
         super().__init__()
 
     # Implements drivers method
-    def init(self, configuration: dict):
-        ...
+    def init(configuration: dict):
+        DownloadDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, item: Item) -> bool:

--- a/extensions/aproc/proc/drivers/abstract_driver.py
+++ b/extensions/aproc/proc/drivers/abstract_driver.py
@@ -3,15 +3,17 @@ from aproc.core.logger import Logger
 
 
 class AbstractDriver(ABC):
+    priority: int = 0
+    name: str = ""
+    LOGGER = Logger.logger
+    assets_dir: str = ""
 
     def __init__(self):
-        self.priority: int = 0
-        self.name: str = ""
-        self.LOGGER = Logger.logger
-        self.assets_dir: str = ""
-
+        ...
+        
+    @staticmethod
     @abstractmethod
-    def init(self, configuration: dict) -> None:
+    def init(configuration: dict) -> None:
         """Method called at init time by the service.
 
         Args:

--- a/extensions/aproc/proc/drivers/driver_manager.py
+++ b/extensions/aproc/proc/drivers/driver_manager.py
@@ -16,12 +16,12 @@ class DriverManager():
         DriverManager.drivers[process] = []
         for driver_configuration in drivers:
             try:
-                driver: AbstractDriver = importlib.import_module(driver_configuration.class_name).Driver()
-                driver.init(driver_configuration.configuration)
-                driver.priority = driver_configuration.priority
-                driver.name = driver_configuration.name
-                driver.assets_dir = driver_configuration.assets_dir
-                DriverManager.drivers[process].append(driver)
+                driver_class: AbstractDriver = importlib.import_module(driver_configuration.class_name).Driver
+                driver_class.init(driver_configuration.configuration)
+                driver_class.priority = driver_configuration.priority
+                driver_class.name = driver_configuration.name
+                driver_class.assets_dir = driver_configuration.assets_dir
+                DriverManager.drivers[process].append(driver_class)
             except ModuleNotFoundError:
                 raise DriverException("Driver {} not found".format(driver_configuration.class_name))
         DriverManager.drivers[process].sort(key=lambda driver: driver.priority)
@@ -31,21 +31,14 @@ class DriverManager():
     @staticmethod
     def solve(process: str, ressource) -> AbstractDriver:
         DriverManager.__check_drivers(process)
-        for driver in DriverManager.drivers.get(process, []):
+        for driver_class in DriverManager.drivers.get(process, []):
             try:
-                LOGGER.debug("Test driver {}".format(driver.name))
+                LOGGER.debug("Test driver {}".format(driver_class.name))
+                driver: AbstractDriver = driver_class()
                 if driver.supports(ressource) is True:
                     return driver
             except Exception as e:
                 LOGGER.exception(e)
-        return None
-
-    @staticmethod
-    def get_driver_by_name(process: str, name_to_find: str) -> AbstractDriver:
-        DriverManager.__check_drivers(process)
-        for driver in DriverManager.drivers.get(process, []):
-            if driver.name == name_to_find:
-                return driver
         return None
 
     @staticmethod

--- a/extensions/aproc/proc/enrich/drivers/enrich_driver.py
+++ b/extensions/aproc/proc/enrich/drivers/enrich_driver.py
@@ -6,15 +6,17 @@ from extensions.aproc.proc.drivers.abstract_driver import AbstractDriver
 
 
 class EnrichDriver(AbstractDriver):
+    alternative_asset_href_field = None
 
     def __init__(self):
-        super().__init__()        
+        super().__init__()
         self.thumbnail_size = 256
         self.overview_size = 1024
-        self.alternative_asset_href_field: str = None
 
-    def init(self, configuration: dict) -> None:
-        self.alternative_asset_href_field = configuration.get("alternative_asset_href_field")
+    @staticmethod
+    def init(configuration: dict) -> None:
+        if configuration:
+            EnrichDriver.alternative_asset_href_field = configuration.get("alternative_asset_href_field")
 
     def get_assets_dir(self, url: str) -> str:
         """Provides the directory for storing the assets

--- a/extensions/aproc/proc/enrich/drivers/impl/safe.py
+++ b/extensions/aproc/proc/enrich/drivers/impl/safe.py
@@ -19,13 +19,15 @@ from extensions.aproc.proc.s3_configuration import S3Configuration
 class Driver(EnrichDriver):
 
     SUPPORTED_ASSET_TYPES = [AssetFormat.cog.value.lower()]
+    configuration: S3Configuration = None
 
     def __init__(self):
         super().__init__()
 
     # Implements drivers method
-    def init(self, configuration: dict):
-        self.configuration = S3Configuration.model_validate(configuration)
+    def init(configuration: dict):
+        EnrichDriver.init(configuration)
+        Driver.configuration = S3Configuration.model_validate(configuration)
 
     # Implements drivers method
     def supports(self, item: Item) -> bool:
@@ -83,7 +85,7 @@ class Driver(EnrichDriver):
 
     def __download_TCI(self, href: str):
         storage_type = urlparse(href).scheme
-        transport_params = self.configuration.get_storage_parameters(href, self.LOGGER)
+        transport_params = Driver.configuration.get_storage_parameters(href, self.LOGGER)
 
         # With GS, it has been observed that performances for extracting a file directly from the zip remotely
         # Is far more slower than downloading the whole archive and then unzipping
@@ -101,7 +103,7 @@ class Driver(EnrichDriver):
 
             # Remove temporary archive
             os.remove(tmp_file)
-        elif self.configuration.is_download_required(href):
+        elif Driver.configuration.is_download_required(href):
             import requests
 
             requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)

--- a/extensions/aproc/proc/ingest/drivers/impl/ast_dem.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/ast_dem.py
@@ -44,8 +44,8 @@ class Driver(IngestDriver):
         self.tfw_path = None
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        return
+    def init(configuration: dict):
+        IngestDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, url: str) -> bool:
@@ -240,8 +240,7 @@ class Driver(IngestDriver):
         return item
 
     def __check_path__(self, path: str):
-        self.tif_path = None
-        self.met_path = None
+        self.__init__()
         valid_and_exist = os.path.isdir(path) and os.path.exists(path)
         if valid_and_exist:
             for f in os.listdir(path):

--- a/extensions/aproc/proc/ingest/drivers/impl/cosmoskymed.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/cosmoskymed.py
@@ -13,24 +13,25 @@ import xml.etree.ElementTree as ET
 
 
 class Driver(IngestDriver):
+    output_folder: str = None  # todo: this should use self.get_asset_filepath instead
 
     def __init__(self):
         super().__init__()
-        self.browse_path = None
-        self.quicklook_path = None
-        self.thumbnail_path = None
         self.tif_path = None
         self.tfw_path = None
-        self.h5_path = None
-        self.h5pdf_path = None
         self.met_path = None
         self.attr_path = None
+        self.browse_path = None
         self.prefix_key = None
-        self.output_folder = None
+        self.h5_path = None
+        self.h5pdf_path = None
+        self.quicklook_path = None
+        self.thumbnail_path = None
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        self.output_folder = configuration['tmp_directory']
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
+        Driver.output_folder = configuration['tmp_directory']
         return
 
     # Implements drivers method
@@ -47,14 +48,14 @@ class Driver(IngestDriver):
     def identify_assets(self, url: str) -> list[Asset]:
         assets = []
         if self.browse_path is not None:
-            thumbnail_path = self.output_folder + '/' + self.get_item_id(url) + '/thumbnail'
+            thumbnail_path = Driver.output_folder + '/' + self.get_item_id(url) + '/thumbnail'
             os.makedirs(thumbnail_path, exist_ok=True)
             self.thumbnail_path = thumbnail_path + '/thumbnail.jpg'
             geotiff_to_jpg(self.browse_path, 50, 50, self.thumbnail_path)
             assets.append(Asset(href=self.thumbnail_path,
                                 roles=[Role.thumbnail.value], name=Role.thumbnail.value, type=MimeType.JPG.value,
                                 description=Role.thumbnail.value, size=get_file_size(self.thumbnail_path), asset_format=AssetFormat.jpg.value))
-            quicklook_path = self.output_folder + '/' + self.get_item_id(url) + '/quicklook'
+            quicklook_path = Driver.output_folder + '/' + self.get_item_id(url) + '/quicklook'
             os.makedirs(quicklook_path, exist_ok=True)
             self.quicklook_path = quicklook_path + '/quicklook.jpg'
             geotiff_to_jpg(self.browse_path, 250, 250, self.quicklook_path)
@@ -148,15 +149,7 @@ class Driver(IngestDriver):
         return item
 
     def __check_path__(self, file_path: str):
-        self.tif_path = None
-        self.met_path = None
-        self.attr_path = None
-        self.browse_path = None
-        self.prefix_key = None
-        self.h5_path = None
-        self.h5pdf_path = None
-        self.quicklook_path = None
-        self.thumbnail_path = None
+        self.__init__()
         valid_and_exist = os.path.isfile(file_path) and os.path.exists(file_path)
         file_name = os.path.basename(file_path)
         path = os.path.dirname(file_path)

--- a/extensions/aproc/proc/ingest/drivers/impl/digitalglobe.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/digitalglobe.py
@@ -25,8 +25,8 @@ class Driver(IngestDriver):
         self.tfw_path = None
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        return
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, url: str) -> bool:
@@ -162,12 +162,7 @@ class Driver(IngestDriver):
         return item
 
     def __check_path__(self, path: str):
-        self.thumbnail_path = None
-        self.quicklook_path = None
-        self.tif_path = None
-        self.xml_path = None
-        self.til_path = None
-        self.imd_path = None
+        self.__init__()
         valid_and_exist = os.path.isdir(path) and os.path.exists(path)
         if valid_and_exist is True:
             for file in os.listdir(path):

--- a/extensions/aproc/proc/ingest/drivers/impl/dimap.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/dimap.py
@@ -23,8 +23,8 @@ class Driver(IngestDriver):
         self.georef_path = None
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        ...
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, url: str) -> bool:
@@ -215,11 +215,8 @@ class Driver(IngestDriver):
 
     def __check_path__(self, path: str):
         # relative_folder_path variable must be a folder path beginning and finishing with a /
+        self.__init__()
         valid_and_exist = os.path.isdir(path) and os.path.exists(path)
-        self.thumbnail_path = None
-        self.quicklook_path = None
-        self.roi_path = None
-        self.dim_path = None
         cat_all_thumb_path = None
         cat_all_quick_path = None
         raw_all_thumb_path = None

--- a/extensions/aproc/proc/ingest/drivers/impl/geoeye.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/geoeye.py
@@ -24,8 +24,8 @@ class Driver(IngestDriver):
         self.component_id = None
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        return
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, url: str) -> bool:
@@ -167,11 +167,7 @@ class Driver(IngestDriver):
         return item
 
     def __check_path__(self, file_path: str):
-        self.tif_path = None
-        self.met_path = None
-        self.quicklook_path = None
-        self.thumbnail_path = None
-        self.component_id = None
+        self.__init__()
         valid_and_exist = os.path.isfile(file_path) and os.path.exists(file_path)
         file_name = os.path.basename(file_path)
         path = os.path.dirname(file_path)

--- a/extensions/aproc/proc/ingest/drivers/impl/jpeg2000.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/jpeg2000.py
@@ -12,8 +12,8 @@ class Driver(IngestDriver):
         super().__init__()
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        ...
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, url: str) -> bool:

--- a/extensions/aproc/proc/ingest/drivers/impl/rapideye.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/rapideye.py
@@ -25,8 +25,8 @@ class Driver(IngestDriver):
         self.tfw_path = None
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        ...
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, url: str) -> bool:
@@ -134,10 +134,7 @@ class Driver(IngestDriver):
         return item
 
     def __check_path__(self, path: str):
-        self.thumbnail_path = None
-        self.quicklook_path = None
-        self.tif_path = None
-        self.xml_path = None
+        self.__init__()
         valid_and_exist = os.path.isdir(path) and os.path.exists(path)
         if valid_and_exist is True:
             for file in os.listdir(path):

--- a/extensions/aproc/proc/ingest/drivers/impl/spot5.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/spot5.py
@@ -20,11 +20,10 @@ class Driver(IngestDriver):
         self.tfw_path = None
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        ...
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
 
     # Implements drivers method
-    @staticmethod
     def supports(self, url: str) -> bool:
         try:
             result = self.__check_path__(url)
@@ -121,10 +120,7 @@ class Driver(IngestDriver):
         return item
 
     def __check_path__(self, path: str):
-        self.thumbnail_path = None
-        self.quicklook_path = None
-        self.tif_path = None
-        self.dim_path = None
+        self.__init__()
         valid_and_exist = os.path.isdir(path) and os.path.exists(path)
         if valid_and_exist is True:
             for file in os.listdir(path):

--- a/extensions/aproc/proc/ingest/drivers/impl/terrasarx.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/terrasarx.py
@@ -13,6 +13,8 @@ import xml.etree.ElementTree as ET
 
 
 class Driver(IngestDriver):
+    output_folder = None
+
     def __init__(self):
         super().__init__()
         self.browse_path = None
@@ -21,11 +23,11 @@ class Driver(IngestDriver):
         self.tif_path = None
         self.tfw_path = None
         self.met_path = None
-        self.output_folder = None
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        self.output_folder = configuration['tmp_directory']  # todo: this should use self.get_asset_filepath instead
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
+        Driver.output_folder = configuration['tmp_directory']  # todo: this should use self.get_asset_filepath instead
 
     # Implements drivers method
     def supports(self, url: str) -> bool:
@@ -144,9 +146,7 @@ class Driver(IngestDriver):
         return item
 
     def __check_path__(self, path: str):
-        self.tif_path = None
-        self.met_path = None
-        self.browse_path = None
+        self.__init__()
         valid_and_exist = os.path.isdir(path) and os.path.exists(path)
         if valid_and_exist:
             for f in os.listdir(path):

--- a/extensions/aproc/proc/ingest/drivers/impl/tiff.py
+++ b/extensions/aproc/proc/ingest/drivers/impl/tiff.py
@@ -12,8 +12,8 @@ class Driver(IngestDriver):
         super().__init__()
 
     # Implements drivers method
-    def init(self, configuration: Configuration):
-        ...
+    def init(configuration: Configuration):
+        IngestDriver.init(configuration)
 
     # Implements drivers method
     def supports(self, url: str) -> bool:

--- a/extensions/aproc/proc/ingest/drivers/ingest_driver.py
+++ b/extensions/aproc/proc/ingest/drivers/ingest_driver.py
@@ -4,14 +4,19 @@ from abc import abstractmethod
 from airs.core.models.model import Asset, Item
 from extensions.aproc.proc.drivers.abstract_driver import AbstractDriver
 from extensions.aproc.proc.drivers.exceptions import DriverException
+from aproc.core.settings import Configuration
 
 
 class IngestDriver(AbstractDriver):
 
     def __init__(self):
-        super().__init__()        
+        super().__init__()
         self.thumbnail_size = 256
         self.overview_size = 1024
+
+    # Implements drivers method
+    def init(configuration: Configuration):
+        return
 
     def get_assets_dir(self, url: str) -> str:
         """Provides the directory for storing the assets


### PR DESCRIPTION
fix #221 

Drivers were used as a singleton object. This is not suitable for parallel processing on single node. Also, re-initializing properly the object was necessary.

What is proposed in this PR is to register the Driver class and to init the class with the configuration. Then the `solve` method instantiate the object so that the process can do what ever is suitable. Also, the implementation driver object has its own object attributes that are proper to one single call.

Changes:
- `init` becomes a class method, called when the Driver class are loaded
- Fields that are proper to the Driver class move to the class (initialized at driver loading), such as `alternative_asset_href_field ` or `configuration: ZarrConfiguration`. 
- all drivers are impacted, but for small changes
- when possible, the init of variables are done in `__init__` of the driver to reduce code duplication.