### PR TITLE
Fix/mkdocs script

### DIFF
--- a/mkDocs.sh
+++ b/mkDocs.sh
@@ -29,6 +29,7 @@ pip3.10 install lazydocs
 
 export PYTHONPATH=python
 
+pip3.10 install -r python/aias_common/requirements.txt
 lazydocs \
     aias_common.access.manager \
     aias_common.access.configuration \

--- a/python/aias_common/requirements.txt
+++ b/python/aias_common/requirements.txt
@@ -6,3 +6,4 @@ pydantic==2.10.6
 requests==2.31.0
 smart_open==6.2.0
 boto3==1.24.89
+uvicorn==0.34.2

--- a/test/stop_stack.sh
+++ b/test/stop_stack.sh
@@ -1,2 +1,4 @@
-source ./test/env.sh
+# Set env variable
+. ./test/env.sh
+
 docker compose -f docker/compose/docker-compose.yaml -f docker/compose/docker-compose-tests.yaml down


### PR DESCRIPTION
Changes:
- Add uvicorn to aias_common requirements
- Install aias_common requirement to generate doc with lazydoc
- Set the env variable with `.` instead of `source`, as done in start_stack.sh