### PR TITLE
Generalise readable/writable paths for any storage (local and remote)

### DIFF
--- a/conf/aproc.yaml
+++ b/conf/aproc.yaml
@@ -41,6 +41,8 @@ access_manager:
         - /inputs
     -
       type: gs
+      readable_paths:
+        - gs://gisaia-public
       bucket: gisaia-public
       # api_key:
       #   project_id: $APROC_INPUT_STORAGE_API_KEY_PROJECT

--- a/conf/aproc.yaml
+++ b/conf/aproc.yaml
@@ -50,6 +50,8 @@ access_manager:
       #   private_key: $APROC_INPUT_STORAGE_API_KEY_PRIVATE_KEY
     -
       type: s3
+      readable_paths:
+        - http://minio:9000/archives/inputs
       bucket: archives
       endpoint: "http://minio:9000"
     # -

--- a/python/aias_common/access/configuration.py
+++ b/python/aias_common/access/configuration.py
@@ -14,13 +14,13 @@ class AccessType(enum.Enum):
 class StorageConfiguration(BaseModel, extra='allow'):
     type: str = Field(title='Storage type', description="Type of the storage used")
     is_local: bool = Field(title='Is a local storage', description="Whether the storage is local or remote")
+    writable_paths: list[str] = Field(default=[], title="Writable Paths", description="List of paths where files can be written")
+    readable_paths: list[str] = Field(default=[], title="Readable Paths", description="List of paths from which files can be read")
 
 
 class FileStorageConfiguration(StorageConfiguration):
     type: Literal["file"] = Field(default="file", title="Type", description="Indicates the storage type, fixed to 'file'")
     is_local: Literal[True] = Field(default=True, title='Is a local storage', description="Whether the storage is local or remote")
-    writable_paths: list[str] = Field(default=[], title="Writable Paths", description="List of paths where files can be written")
-    readable_paths: list[str] = Field(default=[], title="Readable Paths", description="List of paths from which files can be read")
 
 
 class GoogleStorageConstants(str, enum.Enum):

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -74,24 +74,22 @@ class AccessManager:
         return storage.get_storage_parameters()
 
     @staticmethod
-    def check_local_path_writable(href: str):
+    def check_path_writable(href: str):
         """
         Checks that the path is a writable path for at least one of the file storages
         """
-        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.WRITE),
-                                filter(lambda s: s.storage_configuration.type == "file", AccessManager.storages)))
+        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.WRITE),AccessManager.storages))
         if not is_authorized:
-            raise ValueError(f"Local path '{href}' is not writable")
+            raise ValueError(f"Path '{href}' is not writable")
 
     @staticmethod
-    def check_local_path_readable(href: str):
+    def check_path_readable(href: str):
         """
         Checks that the path is a readable path for at least one of the file storages
         """
-        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.READ),
-                                filter(lambda s: s.storage_configuration.type == "file", AccessManager.storages)))
+        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.READ),AccessManager.storages))
         if not is_authorized:
-            raise ValueError(f"Local path '{href}' is not readable")
+            raise ValueError(f"Path '{href}' is not readable")
 
     @staticmethod
     def push(href: str, dst: str):
@@ -99,9 +97,10 @@ class AccessManager:
         Push a file from a local storage to write it in a storage.
         If the destination storage is local, then it is a copy. Otherwise it is an upload.
         """
-        storage = AccessManager.resolve_storage(dst)
-        AccessManager.check_local_path_readable(href)
+        AccessManager.check_path_readable(href)
+        AccessManager.check_path_writable(dst)
 
+        storage = AccessManager.resolve_storage(dst)
         storage.push(href, dst)
 
     @staticmethod
@@ -110,9 +109,10 @@ class AccessManager:
         Pulls a file from a storage to write it in the local storage.
         If the input storage is local, then it is a copy. Otherwise it is a download.
         """
-        storage = AccessManager.resolve_storage(href)
-        AccessManager.check_local_path_writable(dst)
+        AccessManager.check_path_readable(href)
+        AccessManager.check_path_writable(dst)
 
+        storage = AccessManager.resolve_storage(href)
         storage.pull(href, dst)
 
     @staticmethod

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -49,7 +49,7 @@ class AccessManager:
             map(lambda s: s.is_path_authorized(tmp_dir, AccessType.WRITE),
                 filter(lambda s: s.storage_configuration.type == "file", AccessManager.storages)))
         if not is_tmp_dir_authorized:
-            raise ValueError("The given tmp_dir is not part of any defined FileStorage with WRITE authorization")
+            raise PermissionError("The given tmp_dir is not part of any defined FileStorage with WRITE authorization")
 
         AccessManager.tmp_dir = tmp_dir
 
@@ -80,7 +80,7 @@ class AccessManager:
         """
         is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.WRITE),AccessManager.storages))
         if not is_authorized:
-            raise ValueError(f"Path '{href}' is not writable")
+            raise PermissionError(f"Path '{href}' is not writable")
 
     @staticmethod
     def check_path_readable(href: str):
@@ -89,7 +89,7 @@ class AccessManager:
         """
         is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.READ),AccessManager.storages))
         if not is_authorized:
-            raise ValueError(f"Path '{href}' is not readable")
+            raise PermissionError(f"Path '{href}' is not readable")
 
     @staticmethod
     def push(href: str, dst: str):
@@ -264,14 +264,14 @@ class AccessManager:
                 for f in AccessManager.listdir(href):
                     folder_size += AccessManager.get_size(f.path)
                 return folder_size
-        raise ValueError(f"Given href does not exist {href}")
+        raise FileNotFoundError(f"Given href does not exist: {href}")
 
     @staticmethod
     def listdir(href: str) -> list[File]:
         storage = AccessManager.resolve_storage(href)
 
         if not storage.is_dir(href):
-            raise ValueError("Given href does not point to a directory ({})".format(href))
+            raise NotADirectoryError(f"Given href does not point to a directory: {href}")
 
         return storage.listdir(href)
 

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -207,7 +207,8 @@ class AbstractStorage(ABC):
         Args:
             href(str): The href to delete
         """
-        ...
+        if not self.is_path_authorized(href, AccessType.WRITE):
+            raise PermissionError(f'The desired path ({href}) is not authorized to write (for deletion)')
 
     @abstractmethod
     def get_gdal_stream_options(self) -> dict:

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -1,9 +1,11 @@
 import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from urllib.parse import urlparse
 
-from aias_common.access.configuration import AnyStorageConfiguration
+from aias_common.access.configuration import AnyStorageConfiguration, AccessType
 from aias_common.access.file import File
+from aias_common.access.storages.utils import remote_path_starts_with
 
 
 class AbstractStorage(ABC):
@@ -25,11 +27,32 @@ class AbstractStorage(ABC):
     @abstractmethod
     def get_storage_parameters(self) -> dict:
         """Based on the type of storage and its characteristics, gives storage-specific parameters to use to access data
+        """
+        ...
+
+    def is_path_authorized(self, href: str, action: AccessType) -> bool:
+        """Check whether a given action is permitted on the specified path.
 
         Args:
             href (str): Href of the file to consult
+            action (AccessType): Action to check permission for, on the specified path
+
+        Returns:
+            bool: True if the action is authorized, False otherwise
         """
-        ...
+        # Get the list of accessible paths for the given action
+        if action == AccessType.WRITE:
+            paths = self.get_configuration().writable_paths
+        if action == AccessType.READ:
+            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+        # Check if the given path is a sub-path of the authorized paths
+        if self.storage_configuration.is_local:
+            is_authorized = any(list(map(lambda p: Path(href).is_relative_to(Path(p)), paths)))
+        else:
+            is_authorized =  any(list(map(lambda p: remote_path_starts_with(path=href, prefix=p), paths)))
+        return is_authorized
+
+
 
     @abstractmethod
     def supports(self, href: str) -> bool:

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -76,13 +76,11 @@ class FileStorage(AbstractStorage):
         return os.path.dirname(os.path.abspath(href))
 
     def clean(self, href: str):
-        if self.is_path_authorized(href, AccessType.WRITE):
-            if self.is_dir(href):
-                shutil.rmtree(href)  # !DELETE!
-            else:
-                os.remove(href)  # !DELETE!
+        super().clean(href=href)
+        if self.is_dir(href):
+            shutil.rmtree(href)  # !DELETE!
         else:
-            raise ValueError("The given path is read-only")
+            os.remove(href)  # !DELETE!
 
     def get_gdal_stream_options(self):
         return {}

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -66,7 +66,7 @@ class FileStorage(AbstractStorage):
 
     def makedir(self, href: str, strict=False):
         if not self.is_path_authorized(href, AccessType.WRITE):
-            raise ValueError('The desired folder is not authorized')
+            raise PermissionError(f'The desired folder path is not authorized to write: {href}')
 
         if not self.exists(href) or strict:
             os.makedirs(href)

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -28,26 +28,13 @@ class FileStorage(AbstractStorage):
     def get_rasterio_session(self):
         return {}
 
-    def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        if action == AccessType.WRITE:
-            paths = self.get_configuration().writable_paths
-        if action == AccessType.READ:
-            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
-        return any(list(map(lambda p: os.path.commonpath([p, href]) == p, paths)))
-
     def pull(self, href: str, dst: str):
         super().pull(href, dst)
-
-        if not self.is_path_authorized(dst, AccessType.WRITE):
-            raise ValueError('The desired output path is not authorized')
 
         shutil.copy(href, dst)
 
     def push(self, href: str, dst: str, content_type: str | None = None):
         super().push(href, dst)
-
-        if not self.is_path_authorized(dst, AccessType.WRITE):
-            raise ValueError('The desired output path is not authorized')
 
         shutil.copy(href, dst)
 
@@ -65,7 +52,8 @@ class FileStorage(AbstractStorage):
 
     def __to_file__(self, base: str, name: str):
         path = os.sep.join([base.removesuffix("/"), name])
-        f = File(name=name, path=path, is_dir=os.path.isdir(path), last_modification_date=os.path.getmtime(path), creation_date=os.path.getctime(path))
+        f = File(name=name, path=path, is_dir=os.path.isdir(path), last_modification_date=os.path.getmtime(path),
+                 creation_date=os.path.getctime(path))
         if f.is_dir:
             f.path = f.path.removesuffix("/") + "/"
         return f

--- a/python/aias_common/access/storages/utils.py
+++ b/python/aias_common/access/storages/utils.py
@@ -20,3 +20,22 @@ def requests_head(href: str, headers: dict) -> requests.Response:
 def requests_exists(href: str, headers: dict) -> bool:
     r = requests_head(href, headers)
     return r.status_code >= 200 and r.status_code < 300
+
+
+def remote_path_starts_with(path: str, prefix: str) -> bool:
+    """
+    Check whether a remote path (e.g., a cloud storage URI) is under a given prefix.
+
+    This function normalizes both `path` and `prefix` by stripping trailing slashes,
+    then checks whether `path` is exactly equal to `prefix` or is a subpath of it.
+
+    Parameters:
+        path (str): The full remote path to check, e.g., "gs://bucket/folder/file.txt".
+        prefix (str): The expected prefix path, e.g., "gs://bucket/folder".
+
+    Returns:
+        bool: True if `path` is equal to or is a subpath of `prefix`, False otherwise.
+    """
+    path = path.rstrip("/")
+    prefix = prefix.rstrip("/")
+    return path == prefix or path.startswith(prefix + "/")

--- a/python/extensions/aproc/proc/drivers/driver_manager.py
+++ b/python/extensions/aproc/proc/drivers/driver_manager.py
@@ -27,7 +27,7 @@ class DriverManager():
                 raise DriverException("Driver {} not found".format(driver_configuration.class_name))
 
             try:
-                AccessManager.check_local_path_writable(driver_class.assets_dir)
+                AccessManager.check_path_writable(driver_class.assets_dir)
                 if driver_class.assets_dir == "/":
                     raise ValueError("Driver {} assets_dir is not authorized for writing".format(driver_configuration.class_name))
             except ValueError as e:


### PR DESCRIPTION
Changes:
- Add the readable/writable path check also for remote paths
- Generalize the writable path checking before cleaning

Note:
- `readable_paths` and `writable_paths` must be explicitely defined in storage yml configuration 

- Fix https://github.com/gisaia/aias/issues/282
