### PR TITLE
add url access rbac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ env_aias/
 angular/file-explorer/node_modules
 angular/file-explorer/.angular
 angular/file-explorer/dist
+
+conf/roles.yaml

--- a/conf/agate.yaml
+++ b/conf/agate.yaml
@@ -18,3 +18,8 @@ services:
     url_header: $AGATE_URL_HEADER|X-Forwarded-Uri
     url_header_prefix: $AGATE_URL_HEADER_PREFIX
     pattern_target: $TITILER_PATTERN_TARGET|query.url.url.path # takes the query parametters, use it as a url, then extract the path
+urbac:
+  url_header: $AGATE_URL_HEADER|x-forwarded-uri
+  method_header: $AGATE_METHOD_HEADER|x-forwarded-method
+  jwt_header: $AGATE_JWT_HEADER|authorization
+  role_file: conf/roles.yaml

--- a/python/agate/requirements.txt
+++ b/python/agate/requirements.txt
@@ -7,3 +7,4 @@ envyaml==1.10.211231
 requests==2.31.0
 attrs==23.1.0
 ecs-logging==2.1.0
+PyJWT==2.8.0

--- a/python/agate/rest/service.py
+++ b/python/agate/rest/service.py
@@ -1,6 +1,6 @@
 
 import re
-
+import jwt
 import requests
 from fastapi import APIRouter, Request, status
 from fastapi.responses import Response
@@ -11,10 +11,48 @@ from urllib import parse
 
 LOGGER = Logger.logger
 ROUTER = APIRouter()
+MISSING_MSG = "{} missing"
+
+@ROUTER.get("/url-role-based-authorization")
+async def urbac(request: Request):
+    LOGGER.debug(request.headers)
+    request_path = request.headers[Configuration.settings.urbac.url_header]
+    if not request_path:
+        return Response(status_code=status.HTTP_401_UNAUTHORIZED, content=MISSING_MSG.format(Configuration.settings.urbac.url_header))
+    request_method = request.headers[Configuration.settings.urbac.method_header]
+    if not request_method:
+        return Response(status_code=status.HTTP_401_UNAUTHORIZED, content=MISSING_MSG.format(Configuration.settings.urbac.method_header))
+    authorization = request.headers[Configuration.settings.urbac.jwt_header]
+    LOGGER.debug("Incoming request: {} on {}".format(request_method, request_path))
+    if authorization:
+        token = jwt.decode(authorization.removeprefix("Bearer "), options={"verify_signature": False})  # NOSONAR
+        user_roles = token.get("resource_access", {}).get("arlas-backend", {}).get("roles", [])
+        LOGGER.debug("User's roles {}".format(", ".join(user_roles)))
+        for n, r in Configuration.settings.urbac.roles.technicalRoles.items():
+            if n in user_roles:
+                for p in r.permissions:
+                    components = p.split(":")
+                    if len(components) == 3:
+                        role_type, url_pattern, verbs = components
+                        if role_type == "r":
+                            if request_method.lower() in verbs.lower().split(","):
+                                matches = re.finditer(pattern=url_pattern, string=request_path)
+                                for match in matches:
+                                    if match.start() == 0:
+                                        LOGGER.debug("{} matches {}".format(request_path, url_pattern))
+                                        return Response(status_code=status.HTTP_202_ACCEPTED)
+                                LOGGER.debug("{} does not matches {}".format(request_path, url_pattern))
+                    else:
+                        LOGGER.warning("unrecognized permission {}".format(p))
+            else:
+                LOGGER.debug("user hasn't role {}".format(n))
+    else:
+        return Response(status_code=status.HTTP_401_UNAUTHORIZED, content=MISSING_MSG.format(Configuration.settings.urbac.jwt_header))
+    return Response(status_code=status.HTTP_403_FORBIDDEN)
 
 
 @ROUTER.get("/authorization/{service}")
-async def path(request: Request, service: str):
+async def authorization(request: Request, service: str):
     service: Service = Configuration.settings.services.get(service)
     if not service:
         msg = "Service {} not found".format(service)

--- a/python/agate/roles_model.py
+++ b/python/agate/roles_model.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Extra
+
+
+class Role(BaseModel, extra=Extra.allow):
+    description: str | list[str]
+    permissions: list[str]
+
+
+class Roles(BaseModel, extra=Extra.allow):
+    technicalRoles: dict[str, Role]

--- a/python/agate/settings.py
+++ b/python/agate/settings.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, Extra, Field
 from envyaml import EnvYAML
 from agate.logger import Logger
+from agate.roles_model import Roles
+import yaml
 
 LOGGER = Logger.logger
 
@@ -13,12 +15,21 @@ class Service(BaseModel, extra=Extra.allow):
     pattern_target: str | None = Field(title="If undefined, then the pattern is matched against the path. Use query.{param}, where {param} is the parameter value, to use a query parameter. Use query.{param}.url.path|query if the param value is a url and that you want to target the path or query of that url.")
 
 
+class URBAC(BaseModel, extra=Extra.allow):
+    url_header: str
+    method_header: str
+    jwt_header: str
+    roles: Roles = Roles(technicalRoles={})
+    role_file: str
+
+
 class Settings(BaseModel, extra=Extra.allow):
     arlas_url_search: str = Field(title="ARLAS URL Search (ex http://arlas-server:9999/arlas/explore/{collection}/_search?f=id:eq:{item})")
     agate_prefix: str
     host: str
     port: int
     services: dict[str, Service] = Field({}, title="Dictionary of service name/values. Each value is a pattern configuration for extracting collection and id values for building an ARLAS request that determines whether the access is granted or not.")
+    urbac: URBAC
 
 
 class Configuration:
@@ -28,3 +39,6 @@ class Configuration:
     def init(configuration_file: str):
         envyaml = EnvYAML(configuration_file, strict=False)
         Configuration.settings = Settings.model_validate(envyaml.export())
+        with open(Configuration.settings.urbac.role_file, "r") as f:
+            roles = yaml.safe_load(f)
+            Configuration.settings.urbac.roles = Roles.model_validate(roles)

--- a/test/start_stack.sh
+++ b/test/start_stack.sh
@@ -7,7 +7,7 @@ if [ -d "${ROOT_DIRECTORY}/DIMAP" ]; then
 else
     gsutil -m cp -r "gs://gisaia-public/DIMAP" $ROOT_DIRECTORY
 fi
-
+curl https://raw.githubusercontent.com/gisaia/ARLAS-server/refs/tags/v27.0.0/arlas-commons/src/main/resources/roles.yaml -o conf/roles.yaml
 rm -rf ./outbox
 mkdir outbox
 chmod -R 777 outbox

--- a/test/start_stack.sh
+++ b/test/start_stack.sh
@@ -7,7 +7,7 @@ if [ -d "${ROOT_DIRECTORY}/DIMAP" ]; then
 else
     gsutil -m cp -r "gs://gisaia-public/DIMAP" $ROOT_DIRECTORY
 fi
-curl https://raw.githubusercontent.com/gisaia/ARLAS-server/refs/tags/v27.0.0/arlas-commons/src/main/resources/roles.yaml -o conf/roles.yaml
+curl https://raw.githubusercontent.com/gisaia/ARLAS-server/refs/heads/master/arlas-commons/src/main/resources/roles.yaml -o conf/roles.yaml
 rm -rf ./outbox
 mkdir outbox
 chmod -R 777 outbox


### PR DESCRIPTION
Add in agate a new service that checks in [roles.yaml](https://raw.githubusercontent.com/gisaia/ARLAS-server/refs/tags/v27.0.0/arlas-commons/src/main/resources/roles.yaml) if a user can access a requested verb/url

The service opens the user's token and it extracts his roles.
The service then confronts the requested verb/url (e.g. `GET /fam/healthcheck`) to the role's permissions. It tries to make a match (with start=0). For instance, `GET /fam/healthcheck` matches:
```yaml
  role/arlas/datasets:
      permissions:
        - r:/fam/.*:GET,POST
```
[see source](https://github.com/gisaia/ARLAS-server/blob/7c0ff4c6ae91204a965b235e96fedc28e855a9b7/arlas-commons/src/main/resources/roles.yaml#L63)

This service replaces arlas iam `auth` when the deployment is with keycloak.