### PR TITLE
add cache and tests for s3

### DIFF
--- a/docker/compose/docker-compose.yaml
+++ b/docker/compose/docker-compose.yaml
@@ -271,7 +271,6 @@ services:
     build:
       context: '../../'
       dockerfile: docker/Dockerfile-fam
-#    image: fam:latest
     container_name: 'fam-service'
     environment:
       - INGESTED_FOLDER=/inputs
@@ -285,21 +284,39 @@ services:
     ports:
       - "8005:8005"
 
-  fam-bucket-service:
+  fam-gs-service:
     networks:
       - aias
     build:
       context: '../../'
       dockerfile: docker/Dockerfile-fam
-#    image: fam:latest
-    container_name: 'fam-bucket-service'
+    container_name: 'fam-gs-service'
     environment:
       - INGESTED_FOLDER=gs://gisaia-public/
       - FAM_PREFIX=${FAM_PREFIX:-/arlas/fam}
       - FAM_CORS_ORIGINS=${FAM_CORS_ORIGINS:-*}
       - FAM_CORS_METHODS=${FAM_CORS_METHODS:-*}
       - FAM_CORS_HEADERS=${FAM_CORS_HEADERS:-*}
-      - FAM_LOGGER_LEVEL=${FAM_LOGGER_LEVEL:-INFO}
+      - FAM_LOGGER_LEVEL=${FAM_LOGGER_LEVEL:-DEBUG}
       - APROC_CONFIGURATION_FILE=/app/conf/aproc.yaml
     ports:
       - "8006:8005"
+
+
+  fam-s3-service:
+    networks:
+      - aias
+    build:
+      context: '../../'
+      dockerfile: docker/Dockerfile-fam
+    container_name: 'fam-s3-service'
+    environment:
+      - INGESTED_FOLDER=http://minio:9000/archives/inputs
+      - FAM_PREFIX=${FAM_PREFIX:-/arlas/fam}
+      - FAM_CORS_ORIGINS=${FAM_CORS_ORIGINS:-*}
+      - FAM_CORS_METHODS=${FAM_CORS_METHODS:-*}
+      - FAM_CORS_HEADERS=${FAM_CORS_HEADERS:-*}
+      - FAM_LOGGER_LEVEL=${FAM_LOGGER_LEVEL:-DEBUG}
+      - APROC_CONFIGURATION_FILE=/app/conf/aproc.yaml
+    ports:
+      - "8007:8005"

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -271,7 +271,7 @@ class AccessManager:
         storage = AccessManager.resolve_storage(href)
 
         if not storage.is_dir(href):
-            raise ValueError("Given href does not point to a directory")
+            raise ValueError("Given href does not point to a directory ({})".format(href))
 
         return storage.listdir(href)
 

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -8,6 +8,7 @@ from aias_common.access.file import File
 
 class AbstractStorage(ABC):
     cache_tt = 60 * 5
+    cache_size = 2048
 
     def __init__(self, storage_configuration: AnyStorageConfiguration):
         self.storage_configuration = storage_configuration

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -3,12 +3,12 @@ from urllib.parse import urlparse, urlunparse
 
 from aias_common.access.configuration import S3StorageConfiguration
 from aias_common.access.file import File
+from aias_common.access.logger import Logger
 from aias_common.access.storages.abstract import AbstractStorage
 from fastapi_utilities import ttl_lru_cache
-from aias_common.access.logger import Logger
-
 
 LOGGER = Logger.logger
+
 
 class S3Storage(AbstractStorage):
 
@@ -17,25 +17,29 @@ class S3Storage(AbstractStorage):
         return self.storage_configuration
 
     def get_storage_parameters(self):
+        return S3Storage.get_storage_parameters_static(self.get_configuration())
+
+    @staticmethod
+    def get_storage_parameters_static(conf: S3StorageConfiguration):
         import boto3
 
-        if self.get_configuration().is_anon_client:
+        if conf.is_anon_client:
             from botocore import UNSIGNED
             from botocore.client import Config
 
             client = boto3.client(
                 "s3",
-                region_name=self.get_configuration().region,
-                endpoint_url=self.get_configuration().endpoint,
+                region_name=conf.region,
+                endpoint_url=conf.endpoint,
                 config=Config(signature_version=UNSIGNED)
             )
         else:
             client = boto3.client(
                 "s3",
-                region_name=self.get_configuration().region,
-                endpoint_url=self.get_configuration().endpoint,
-                aws_access_key_id=self.get_configuration().api_key.access_key,
-                aws_secret_access_key=self.get_configuration().api_key.secret_key,
+                region_name=conf.region,
+                endpoint_url=conf.endpoint,
+                aws_access_key_id=conf.api_key.access_key,
+                aws_secret_access_key=conf.api_key.secret_key,
             )
 
         return {"client": client}
@@ -77,12 +81,17 @@ class S3Storage(AbstractStorage):
     def __get_href_key(self, href: str):
         return urlparse(href).path.removeprefix(f"/{self.get_configuration().bucket}").removeprefix("/")
 
+    @staticmethod
+    def __get_href_key_static(conf: S3StorageConfiguration, href: str):
+        return urlparse(href).path.removeprefix(f"/{conf.bucket}").removeprefix("/")
+
+
     def pull(self, href: str, dst: str):
         import botocore.client
 
         super().pull(href, dst)
 
-        client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
+        client: botocore.client.BaseClient = S3Storage.get_storage_parameters_static(self.get_configuration())["client"]
 
         obj = client.get_object(Bucket=self.get_configuration().bucket, Key=self.__get_href_key(href))
         with open(dst, "wb") as f:
@@ -94,35 +103,57 @@ class S3Storage(AbstractStorage):
         raise NotImplementedError("'push' method has not been implemented yet for s3 storage")
 
     def __head_object(self, href: str):
-        print("__head_object {}".format(href))
-        return self.get_storage_parameters()["client"].head_object(
-            Bucket=self.get_configuration().bucket,
-            Key=self.__get_href_key(href))
+        return S3Storage.__head_object_cached(self.get_configuration().model_dump_json(), href)
+
+    @staticmethod
+    @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=1024)
+    def __head_object_cached(conf_json: str, href: str):
+        conf: S3StorageConfiguration = S3StorageConfiguration.model_validate_json(conf_json)
+        if S3Storage.__get_href_key_static(conf, href):
+            try:
+                return S3Storage.get_storage_parameters_static(conf)["client"].head_object(
+                    Bucket=conf.bucket,
+                    Key=S3Storage.__get_href_key_static(conf, href))
+            except:
+                return None
+        else:
+            return None
 
     def is_file(self, href: str):
         import botocore.exceptions
         try:
-            return self.__head_object(href)['ResponseMetadata']['HTTPStatusCode'] == 200
+            response = self.__head_object(href)
+            return (response is not None) and response['ResponseMetadata']['HTTPStatusCode'] == 200
         except botocore.exceptions.ClientError:
             return False
 
     def __list_objects(self, href: str):
+        return S3Storage.__list_objects_cached(self.get_configuration().model_dump_json(), href)
+
+    @staticmethod
+    @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=1024)
+    def __list_objects_cached(conf_json: str, href: str):
+        conf: S3StorageConfiguration = S3StorageConfiguration.model_validate_json(conf_json)
         params = {
-            "Bucket": self.get_configuration().bucket,
+            "Bucket": conf.bucket,
             "Delimiter": "/",
-            "MaxKeys": self.get_configuration().max_objects
+            "MaxKeys": conf.max_objects
         }
-        prefix = self.__get_href_key(href).removesuffix("/") + "/"
+        prefix = S3Storage.__get_href_key_static(conf, href).removesuffix("/") + "/"
         if prefix != "/":
             params["Prefix"] = prefix
-        return self.get_storage_parameters()["client"].list_objects_v2(**params)
+        return S3Storage.get_storage_parameters_static(conf)["client"].list_objects_v2(**params)
 
-    def is_dir(self, href: str):
+    def is_dir(self, href: str) -> bool:
         objects = self.__list_objects(href)
-        return objects['KeyCount'] > 0 or len(objects.get('CommonPrefixes', [])) > 0
+        return (objects is not None) and (objects['KeyCount'] > 0 or len(objects.get('CommonPrefixes', [])) > 0)
 
     def get_file_size(self, href: str):
-        return self.__head_object(href)['ContentLength']
+        response = self.__head_object(href)
+        if response:
+            return self.__head_object(href)['ContentLength']
+        else:
+            return None
 
     def __update_url__(self, source: str, path: str):
         url = urlparse(source)
@@ -154,7 +185,10 @@ class S3Storage(AbstractStorage):
     def get_last_modification_time(self, href: str):        
         import botocore.exceptions
         try:
-            return self.__head_object(href)['LastModified'].timestamp()
+            response = self.__head_object(href)
+            if response:
+                return response['LastModified'].timestamp()
+            return None
         except botocore.exceptions.ClientError:
             return None
         except botocore.exceptions.ParamValidationError:  # key LastModified does not exists for root

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -17,12 +17,8 @@ class S3Storage(AbstractStorage):
         return self.storage_configuration
 
     def get_storage_parameters(self):
-        return S3Storage.get_storage_parameters_static(self.get_configuration())
-
-    @staticmethod
-    def get_storage_parameters_static(conf: S3StorageConfiguration):
         import boto3
-
+        conf = self.get_configuration()
         if conf.is_anon_client:
             from botocore import UNSIGNED
             from botocore.client import Config
@@ -81,17 +77,13 @@ class S3Storage(AbstractStorage):
     def __get_href_key(self, href: str):
         return urlparse(href).path.removeprefix(f"/{self.get_configuration().bucket}").removeprefix("/")
 
-    @staticmethod
-    def __get_href_key_static(conf: S3StorageConfiguration, href: str):
-        return urlparse(href).path.removeprefix(f"/{conf.bucket}").removeprefix("/")
-
 
     def pull(self, href: str, dst: str):
         import botocore.client
 
         super().pull(href, dst)
 
-        client: botocore.client.BaseClient = S3Storage.get_storage_parameters_static(self.get_configuration())["client"]
+        client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
 
         obj = client.get_object(Bucket=self.get_configuration().bucket, Key=self.__get_href_key(href))
         with open(dst, "wb") as f:
@@ -102,18 +94,15 @@ class S3Storage(AbstractStorage):
         super().push(href, dst)
         raise NotImplementedError("'push' method has not been implemented yet for s3 storage")
 
+    @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=AbstractStorage.cache_size)
     def __head_object(self, href: str):
-        return S3Storage.__head_object_cached(self.get_configuration().model_dump_json(), href)
-
-    @staticmethod
-    @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=1024)
-    def __head_object_cached(conf_json: str, href: str):
-        conf: S3StorageConfiguration = S3StorageConfiguration.model_validate_json(conf_json)
-        if S3Storage.__get_href_key_static(conf, href):
+        LOGGER.info("__head_object")
+        conf = self.get_configuration()
+        if self.__get_href_key(href):
             try:
-                return S3Storage.get_storage_parameters_static(conf)["client"].head_object(
+                return self.get_storage_parameters()["client"].head_object(
                     Bucket=conf.bucket,
-                    Key=S3Storage.__get_href_key_static(conf, href))
+                    Key=self.__get_href_key(href))
             except:
                 return None
         else:
@@ -127,22 +116,19 @@ class S3Storage(AbstractStorage):
         except botocore.exceptions.ClientError:
             return False
 
+    @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=AbstractStorage.cache_size)
     def __list_objects(self, href: str):
-        return S3Storage.__list_objects_cached(self.get_configuration().model_dump_json(), href)
-
-    @staticmethod
-    @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=1024)
-    def __list_objects_cached(conf_json: str, href: str):
-        conf: S3StorageConfiguration = S3StorageConfiguration.model_validate_json(conf_json)
+        LOGGER.info("__list_objects")
+        conf = self.get_configuration()
         params = {
             "Bucket": conf.bucket,
             "Delimiter": "/",
             "MaxKeys": conf.max_objects
         }
-        prefix = S3Storage.__get_href_key_static(conf, href).removesuffix("/") + "/"
+        prefix = self.__get_href_key(href).removesuffix("/") + "/"
         if prefix != "/":
             params["Prefix"] = prefix
-        return S3Storage.get_storage_parameters_static(conf)["client"].list_objects_v2(**params)
+        return self.get_storage_parameters()["client"].list_objects_v2(**params)
 
     def is_dir(self, href: str) -> bool:
         objects = self.__list_objects(href)

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -96,7 +96,6 @@ class S3Storage(AbstractStorage):
 
     @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=AbstractStorage.cache_size)
     def __head_object(self, href: str):
-        LOGGER.info("__head_object")
         conf = self.get_configuration()
         if self.__get_href_key(href):
             try:
@@ -118,7 +117,6 @@ class S3Storage(AbstractStorage):
 
     @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=AbstractStorage.cache_size)
     def __list_objects(self, href: str):
-        LOGGER.info("__list_objects")
         conf = self.get_configuration()
         params = {
             "Bucket": conf.bucket,

--- a/python/extensions/aproc/proc/ingest/drivers/impl/ast_dem.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/ast_dem.py
@@ -216,16 +216,17 @@ class Driver(IngestDriver):
 
     def __check_path__(self, path: str):
         self.__init__()
-        for f in AccessManager.listdir(path):
-            self.tif_path = f.path
-            if AccessManager.is_file(self.tif_path) and self.tif_path.lower().endswith((".tif", ".tiff")):
-                tfw_path = os.path.splitext(self.tif_path)[0] + ".tfw"
-                if AccessManager.exists(tfw_path):
-                    self.tfw_path = tfw_path
-                met_path = os.path.splitext(self.tif_path)[0] + ".tif.met"
-                if AccessManager.exists(met_path):
-                    self.met_path = met_path
-                return self.tif_path is not None and self.met_path is not None
+        if AccessManager.is_dir(path):
+            for f in AccessManager.listdir(path):
+                self.tif_path = f.path
+                if AccessManager.is_file(self.tif_path) and self.tif_path.lower().endswith((".tif", ".tiff")):
+                    tfw_path = os.path.splitext(self.tif_path)[0] + ".tfw"
+                    if AccessManager.exists(tfw_path):
+                        self.tfw_path = tfw_path
+                    met_path = os.path.splitext(self.tif_path)[0] + ".tif.met"
+                    if AccessManager.exists(met_path):
+                        self.met_path = met_path
+                    return self.tif_path is not None and self.met_path is not None
         return False
 
     def __get_corner_coord__(self, data, corner):

--- a/test/fam_gs_tests.py
+++ b/test/fam_gs_tests.py
@@ -12,7 +12,7 @@ from fam.core.model import Archive, File, PathRequest
 class Tests(FAMTests):
 
     def setUp(self):
-        FAMTests.URL = "http://fam-gs-service:8005/arlas/fam"
+        FAMTests.URL = "http://fam-gs-service:8005/arlas/fam"  # NOSONAR
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/fam_gs_tests.py
+++ b/test/fam_gs_tests.py
@@ -1,0 +1,18 @@
+import json
+import os
+import unittest
+from test.utils import FAM_URL
+from test.fam_tests import Tests as FAMTests
+import requests
+from fastapi import status
+
+from fam.core.model import Archive, File, PathRequest
+
+
+class Tests(FAMTests):
+
+    def setUp(self):
+        FAMTests.URL = "http://fam-gs-service:8005/arlas/fam"
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/fam_s3_tests.py
+++ b/test/fam_s3_tests.py
@@ -12,7 +12,7 @@ from fam.core.model import Archive, File, PathRequest
 class Tests(FAMTests):
 
     def setUp(self):
-        FAMTests.URL = "http://fam-bucket-service:8005/arlas/fam"
+        FAMTests.URL = "http://fam-s3-service:8005/arlas/fam"
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/fam_s3_tests.py
+++ b/test/fam_s3_tests.py
@@ -12,7 +12,7 @@ from fam.core.model import Archive, File, PathRequest
 class Tests(FAMTests):
 
     def setUp(self):
-        FAMTests.URL = "http://fam-s3-service:8005/arlas/fam"
+        FAMTests.URL = "http://fam-s3-service:8005/arlas/fam"  # NOSONAR
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/fam_tests.py
+++ b/test/fam_tests.py
@@ -40,7 +40,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(archive.name, "IMG_SPOT6_MS_001_A")
         self.assertEqual(archive.path, os.path.join(root.path, "DIMAP/PROD_SPOT6_001/VOL_SPOT6_001_A/IMG_SPOT6_MS_001_A/"))
         self.assertTrue(archive.is_dir)
-        self.assertIn(archive.id, ["148ddaaa431bdd2ff06b823df1e3725d462f668bd95188603bfff443ff055c71", "7fb3088260c163c8bdf37f9b56b35b0232ab8adbb556f9fbfd8d547d26bc20d1"])
+        self.assertIn(archive.id, ["148ddaaa431bdd2ff06b823df1e3725d462f668bd95188603bfff443ff055c71", "7fb3088260c163c8bdf37f9b56b35b0232ab8adbb556f9fbfd8d547d26bc20d1", "a75c9fc5a9fee985be7bd967ef713a20df65e7163f660bf6607436845fb48f4b"])
         self.assertEqual(archive.driver_name, "dimap")
 
 if __name__ == '__main__':

--- a/test/tests_g2.sh
+++ b/test/tests_g2.sh
@@ -15,8 +15,13 @@ echo "run test.agate_tests"
 docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.agate_tests
 
 echo "run test.fam_tests"
-docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.fam_bucket_tests
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.fam_tests
+
+echo "run test.fam_tests s3"
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.fam_s3_tests
+
+echo "run test.fam_tests gs"
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.fam_gs_tests
 
 echo "run test.aproc_ingest_tests"
 docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.aproc_ingest_tests
-

--- a/test/tests_g4_minio.sh
+++ b/test/tests_g4_minio.sh
@@ -9,4 +9,4 @@ docker build -f docker/Dockerfile-tests . -t pythontests
 docker network list
 
 echo "run test.aproc_ingest_tests_minio"
-docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.aproc_ingest_tests_minio Tests.test_ingest_directory
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.aproc_ingest_tests_minio


### PR DESCRIPTION
Add cache on s3 for fetching data on directory content and file MD.
Add tests for gs and s3 within FAM


Notes: to add cache with `@ttl_lru_cache` annotations, I had to use class methods instead of object methods to avoid having the cache based on also `self` parameter.


Fix #302 