### PR TITLE
Improve upload of assets on airs

### DIFF
--- a/docker/Dockerfile-aproc-proc
+++ b/docker/Dockerfile-aproc-proc
@@ -39,6 +39,7 @@ COPY ./conf /app/conf
 COPY ./python/assets /app/assets
 COPY ./python/airs/core /app/airs/core
 COPY ./docker/materials/scripts/aproc-proc/start.sh /app/
+COPY ./docker/materials/scripts/aproc-proc/ping.sh /app/
 
 ENV APROC_CONFIGURATION_FILE=/app/conf/aproc.yaml
 ENV ARLASEO_MAPPING_URL=/app/conf/mapping.json

--- a/docker/materials/scripts/aproc-proc/ping.sh
+++ b/docker/materials/scripts/aproc-proc/ping.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -o errexit -o pipefail
+. aproc/bin/activate
+celery inspect ping --destination worker@$HOSTNAME

--- a/python/agate/requirements.txt
+++ b/python/agate/requirements.txt
@@ -4,7 +4,7 @@ pydantic==2.10.6
 fastapi==0.115.12
 uvicorn==0.23.1
 envyaml==1.10.211231
-requests==2.31.0
+requests==2.32.4
 attrs==23.1.0
 ecs-logging==2.1.0
 PyJWT==2.8.0

--- a/python/agate/rest/service.py
+++ b/python/agate/rest/service.py
@@ -25,7 +25,13 @@ async def urbac(request: Request):
     authorization = request.headers[Configuration.settings.urbac.jwt_header]
     LOGGER.debug("Incoming request: {} on {}".format(request_method, request_path))
     if authorization:
-        token = jwt.decode(authorization.removeprefix("Bearer ").removeprefix("bearer "), options={"verify_signature": False})  # NOSONAR
+        try:
+            token = jwt.decode(authorization.removeprefix("Bearer ").removeprefix("bearer "), options={"verify_signature": False})  # NOSONAR
+        except Exception as e:
+            msg = "Invalid authorization header value {}".format(e)
+            LOGGER.error(msg)
+            LOGGER.debug(authorization)
+            return Response(status_code=status.HTTP_403_FORBIDDEN, content=msg)
         user_roles = token.get("resource_access", {}).get("arlas-backend", {}).get("roles", [])
         LOGGER.debug("User's roles {}".format(", ".join(user_roles)))
         for n, r in Configuration.settings.urbac.roles.technicalRoles.items():

--- a/python/aias_common/requirements.txt
+++ b/python/aias_common/requirements.txt
@@ -3,7 +3,7 @@ fastapi_utilities==0.3.1
 ecs_logging==2.2.0
 google-cloud-storage==2.5.0
 pydantic==2.10.6
-requests==2.31.0
+requests==2.32.4
 smart_open==6.2.0
 boto3==1.24.89
 uvicorn==0.34.2

--- a/python/airs/requirements.txt
+++ b/python/airs/requirements.txt
@@ -10,6 +10,6 @@ uvicorn==0.23.1
 pytz==2023.3
 python-multipart==0.0.20
 envyaml==1.10.211231
-requests==2.31.0
+requests==2.32.4
 attrs==23.1.0
 ecs-logging==2.1.0

--- a/python/aproc/requirements.txt
+++ b/python/aproc/requirements.txt
@@ -19,3 +19,4 @@ PyJWT==2.8.0
 pillow==10.3.0
 boto3==1.24.89
 fastapi-utilities==0.3.1
+requests-toolbelt==1.0.0

--- a/python/aproc/requirements.txt
+++ b/python/aproc/requirements.txt
@@ -1,7 +1,7 @@
 pydantic==2.10.6
 envyaml==1.10.211231
 celery==5.3.1
-requests==2.31.0
+requests==2.32.4
 celery[redis]==5.3.1
 attrs==23.1.0
 elasticsearch==8.9.0
@@ -12,7 +12,7 @@ fastapi==0.115.12
 uvicorn==0.23.1
 python-multipart==0.0.20
 envyaml==1.10.211231
-requests==2.31.0
+requests==2.32.4
 jsonref==1.1.0
 ecs-logging==2.1.0
 PyJWT==2.8.0

--- a/python/aproc/requirements.txt
+++ b/python/aproc/requirements.txt
@@ -1,7 +1,6 @@
 pydantic==2.10.6
 envyaml==1.10.211231
 celery==5.3.1
-requests==2.32.4
 celery[redis]==5.3.1
 attrs==23.1.0
 elasticsearch==8.9.0

--- a/python/extensions/aproc/proc/processes/arlas_services_helper.py
+++ b/python/extensions/aproc/proc/processes/arlas_services_helper.py
@@ -11,6 +11,9 @@ from aias_common.access.manager import AccessManager
 from extensions.aproc.proc.drivers.exceptions import ConnectionException, RegisterException
 from requests_toolbelt import MultipartEncoder
 
+from aias_common.access.storages.file import FileStorage
+
+
 AIRS_CAN_NOT_BE_REACHED = "AIRS Service can not be reached ({})"
 JSON_HEADER = {"Content-Type": "application/json"}
 
@@ -108,14 +111,17 @@ class ARLASServicesHelper(ABC):
         if asset.airs__managed is True:
             with AccessManager.stream(asset.href) as filedesc:
                 try:
-                    m = MultipartEncoder(
-                        fields={
-                            'file': (asset.name, filedesc, asset.type)
-                        }
-                    )
-                    headers = {'Content-Type': m.content_type}
                     url = os.path.join(airs_endpoint, "collections", item.collection, "items", item.id, "assets", asset.name)
-                    r = requests.post(url=url, data=m, headers=headers)
+                    file = {'file': (asset.name, filedesc, asset.type)}
+                    if isinstance(AccessManager.resolve_storage(asset.href), FileStorage ):
+                        # optimize memory consumption if file. Does not work for smartopen descriptor :=(
+                        m = MultipartEncoder(
+                            fields=file
+                        )
+                        headers = {'Content-Type': m.content_type}
+                        r = requests.post(url=url, data=m, headers=headers)
+                    else:
+                        r = requests.post(url=url, files=file)
                     if r.ok:
                         Process.LOGGER.debug("asset {} uploaded successfully on {}".format(asset.href, url))
                     else:

--- a/python/extensions/aproc/proc/processes/arlas_services_helper.py
+++ b/python/extensions/aproc/proc/processes/arlas_services_helper.py
@@ -113,7 +113,7 @@ class ARLASServicesHelper(ABC):
                 try:
                     url = os.path.join(airs_endpoint, "collections", item.collection, "items", item.id, "assets", asset.name)
                     file = {'file': (asset.name, filedesc, asset.type)}
-                    if isinstance(AccessManager.resolve_storage(asset.href), FileStorage ):
+                    if isinstance(AccessManager.resolve_storage(asset.href), FileStorage):
                         # optimize memory consumption if file. Does not work for smartopen descriptor :=(
                         m = MultipartEncoder(
                             fields=file

--- a/python/extensions/aproc/proc/processes/arlas_services_helper.py
+++ b/python/extensions/aproc/proc/processes/arlas_services_helper.py
@@ -9,6 +9,7 @@ from aproc.core.processes.process import Process
 from airs.core.settings import S3 as S3Configuration
 from aias_common.access.manager import AccessManager
 from extensions.aproc.proc.drivers.exceptions import ConnectionException, RegisterException
+from requests_toolbelt import MultipartEncoder
 
 AIRS_CAN_NOT_BE_REACHED = "AIRS Service can not be reached ({})"
 JSON_HEADER = {"Content-Type": "application/json"}
@@ -106,13 +107,19 @@ class ARLASServicesHelper(ABC):
     def upload_asset_if_managed(item: Item, asset: Asset, airs_endpoint):
         if asset.airs__managed is True:
             with AccessManager.stream(asset.href) as filedesc:
-                file = {'file': (asset.name, filedesc, asset.type)}
                 try:
-                    r = requests.post(url=os.path.join(airs_endpoint, "collections", item.collection, "items", item.id, "assets", asset.name), files=file)
+                    m = MultipartEncoder(
+                        fields={
+                            'file': (asset.name, filedesc, asset.type)
+                        }
+                    )
+                    headers = {'Content-Type': m.content_type}
+                    url = os.path.join(airs_endpoint, "collections", item.collection, "items", item.id, "assets", asset.name)
+                    r = requests.post(url=url, data=m, headers=headers)
                     if r.ok:
-                        Process.LOGGER.debug("asset uploaded successfully")
+                        Process.LOGGER.debug("asset {} uploaded successfully on {}".format(asset.href, url))
                     else:
-                        msg = "Failed to upload asset: {} - {} on {}".format(r.status_code, r.content, airs_endpoint)
+                        msg = "Failed to upload asset {}: {} - {} on {}".format(asset.href, r.status_code, r.content, url)
                         Process.LOGGER.error(msg)
                         raise RegisterException(msg)
                 except requests.exceptions.ConnectionError:

--- a/python/extensions/requirements.ext.txt
+++ b/python/extensions/requirements.ext.txt
@@ -12,4 +12,5 @@ rioxarray==0.17.0
 numpy==1.26.4
 dask==2024.10.0
 matplotlib==3.9.0
+requests-toolbelt==1.0.0
 -r requirements.storage.txt

--- a/python/extensions/requirements.storage.txt
+++ b/python/extensions/requirements.storage.txt
@@ -1,5 +1,5 @@
 google-cloud-storage==2.5.0
 pydantic==2.10.6
-requests==2.31.0
+requests==2.32.4
 smart_open==7.1.0
 boto3==1.24.89

--- a/python/fam/requirements.txt
+++ b/python/fam/requirements.txt
@@ -6,7 +6,7 @@ fastapi==0.115.12
 uvicorn==0.23.1
 envyaml==1.10.211231
 attrs==23.1.0
-requests==2.31.0
+requests==2.32.4
 jsonref==1.1.0
 ecs-logging==2.1.0
 pillow==10.3.0

--- a/python/requirements-stac.txt
+++ b/python/requirements-stac.txt
@@ -2,6 +2,6 @@ click==8.1.6
 typer==0.9.0
 pydantic==2.10.6
 python-dateutil==2.8.2
-requests==2.31.0
+requests==2.32.4
 attrs==23.1.0
 prettytable==3.9.0

--- a/release/materials/aias_common/setup.py
+++ b/release/materials/aias_common/setup.py
@@ -13,6 +13,6 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires='>=3.10',
     package_dir={'': 'src'},
-    install_requires=['ecs_logging', 'google-cloud-storage==2.5.0', 'pydantic==2.10.6', 'requests==2.31.0',
+    install_requires=['ecs_logging', 'google-cloud-storage==2.5.0', 'pydantic==2.10.6', 'requests==2.32.4',
                       'smart_open==6.2.0', 'boto3==1.24.89', 'fastapi_utilities']
 )

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -16,3 +16,4 @@ jsonref==1.1.0
 pillow==10.3.0
 typer==0.9.0
 fastapi-utilities==0.3.1
+requests-toolbelt==1.0.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,7 +5,7 @@ python-dateutil==2.8.2
 fastapi==0.115.12
 python-multipart==0.0.20
 envyaml==1.10.211231
-requests==2.31.0
+requests==2.32.4
 ecs-logging==2.1.0
 uvicorn==0.23.1
 pygeohash==1.2.0


### PR DESCRIPTION
Optimize upload of assets on AIRS:
- use `request.post(data=...)` instead of `request.post(files=...)`  by using `MultipartEncoder` which works only with local file storage and not with smartopen :-(
- this means that we'll still have memory problem during upload of huge files with remote storage.

fix #313 


Side change:
- add a ping in the celery worker (`docker/Dockerfile-aproc-proc` and `docker/materials/scripts/aproc-proc/ping.sh`) to set an healthcheck in ARLAS Explo stack
- upgrade `requests` to `2.32.4` so that it passes CVEs
- add logs for token opening in agate to debug in ARLAS Explo (`python/agate/rest/service.py`)
