### PR TITLE
Feat/authorized path consolidate

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,22 @@ jobs:
           failure-threshold: "error"
           dockerfile: "docker/Dockerfile-${{ matrix.image_name }}"
  
+  aias-tests-am:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install test/requirements
+      run: |
+        pip install -r test/requirements.txt
+    - name: Start stack
+      run: test/start_stack.sh
+    - name: Run g1 tests
+      run: test/tests_am.sh
+
+
   aias-tests-g1:
     runs-on: ubuntu-latest
     steps:

--- a/conf/airs.yaml
+++ b/conf/airs.yaml
@@ -11,6 +11,9 @@ s3:
   region: $AIRS_S3_REGION|None
   tier: $AIRS_S3_TIER|"Standard"
   platform: $AIRS_S3_PLATFORM
+  writable_paths:
+    - /digitalearth.africa
+    - /cubes
 
 # asset_http_endpoint_url must look like https://storage.googleapis.com/{}/{}
 # first element is the bucket, second is the path to the object

--- a/conf/aproc.yaml
+++ b/conf/aproc.yaml
@@ -41,6 +41,8 @@ access_manager:
         - /inputs
     -
       type: gs
+      readable_paths:
+        - gs://gisaia-public
       bucket: gisaia-public
       # api_key:
       #   project_id: $APROC_INPUT_STORAGE_API_KEY_PROJECT

--- a/conf/aproc.yaml
+++ b/conf/aproc.yaml
@@ -50,6 +50,8 @@ access_manager:
       #   private_key: $APROC_INPUT_STORAGE_API_KEY_PRIVATE_KEY
     -
       type: s3
+      readable_paths:
+        - http://minio:9000/archives/inputs
       bucket: archives
       endpoint: "http://minio:9000"
     # -

--- a/conf/aproc.yaml
+++ b/conf/aproc.yaml
@@ -63,3 +63,7 @@ access_manager:
       type: s3
       bucket: downloads
       endpoint: "http://minio:9000"
+      readable_paths:
+        - http://minio:9000/archives/downloads
+      writable_paths:
+        - http://minio:9000/archives/downloads

--- a/conf/aproc.yaml
+++ b/conf/aproc.yaml
@@ -42,7 +42,7 @@ access_manager:
     -
       type: gs
       readable_paths:
-        - gs://gisaia-public
+        - /test-aias
       bucket: gisaia-public
       # api_key:
       #   project_id: $APROC_INPUT_STORAGE_API_KEY_PROJECT
@@ -51,7 +51,7 @@ access_manager:
     -
       type: s3
       readable_paths:
-        - http://minio:9000/archives/inputs
+        - /inputs
       bucket: archives
       endpoint: "http://minio:9000"
     # -
@@ -64,6 +64,6 @@ access_manager:
       bucket: downloads
       endpoint: "http://minio:9000"
       readable_paths:
-        - http://minio:9000/archives/downloads
+        - "/"
       writable_paths:
-        - http://minio:9000/archives/downloads
+        - "/"

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -15,3 +15,5 @@ WORKDIR /app
 
 RUN pip install -r requirements.txt
 RUN pip install -r requirements.storage.txt
+RUN pip install -r requirements.storage.txt
+

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -15,5 +15,4 @@ WORKDIR /app
 
 RUN pip install -r requirements.txt
 RUN pip install -r requirements.storage.txt
-RUN pip install -r requirements.storage.txt
 

--- a/docker/compose/docker-compose.yaml
+++ b/docker/compose/docker-compose.yaml
@@ -292,7 +292,7 @@ services:
       dockerfile: docker/Dockerfile-fam
     container_name: 'fam-gs-service'
     environment:
-      - INGESTED_FOLDER=gs://gisaia-public/
+      - INGESTED_FOLDER=gs://gisaia-public/test-aias
       - FAM_PREFIX=${FAM_PREFIX:-/arlas/fam}
       - FAM_CORS_ORIGINS=${FAM_CORS_ORIGINS:-*}
       - FAM_CORS_METHODS=${FAM_CORS_METHODS:-*}

--- a/python/aias_common/access/configuration.py
+++ b/python/aias_common/access/configuration.py
@@ -14,13 +14,13 @@ class AccessType(enum.Enum):
 class StorageConfiguration(BaseModel, extra='allow'):
     type: str = Field(title='Storage type', description="Type of the storage used")
     is_local: bool = Field(title='Is a local storage', description="Whether the storage is local or remote")
+    writable_paths: list[str] = Field(default=[], title="Writable Paths", description="List of paths where files can be written")
+    readable_paths: list[str] = Field(default=[], title="Readable Paths", description="List of paths from which files can be read")
 
 
 class FileStorageConfiguration(StorageConfiguration):
     type: Literal["file"] = Field(default="file", title="Type", description="Indicates the storage type, fixed to 'file'")
     is_local: Literal[True] = Field(default=True, title='Is a local storage', description="Whether the storage is local or remote")
-    writable_paths: list[str] = Field(default=[], title="Writable Paths", description="List of paths where files can be written")
-    readable_paths: list[str] = Field(default=[], title="Readable Paths", description="List of paths from which files can be read")
 
 
 class GoogleStorageConstants(str, enum.Enum):

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -82,7 +82,7 @@ class AccessManager:
         raise Exception("No local storage configured")
 
     @staticmethod
-    def get_storage_parameters(href: str):
+    def get_storage_parameters(href: str) -> dict:
         storage = AccessManager.resolve_storage(href)
 
         return storage.get_storage_parameters()

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -74,24 +74,22 @@ class AccessManager:
         return storage.get_storage_parameters()
 
     @staticmethod
-    def check_local_path_writable(href: str):
+    def check_path_writable(href: str):
         """
         Checks that the path is a writable path for at least one of the file storages
         """
-        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.WRITE),
-                                filter(lambda s: s.storage_configuration.type == "file", AccessManager.storages)))
+        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.WRITE),AccessManager.storages))
         if not is_authorized:
-            raise ValueError(f"Local path '{href}' is not writable")
+            raise ValueError(f"Path '{href}' is not writable")
 
     @staticmethod
-    def check_local_path_readable(href: str):
+    def check_path_readable(href: str):
         """
         Checks that the path is a readable path for at least one of the file storages
         """
-        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.READ),
-                                filter(lambda s: s.storage_configuration.type == "file", AccessManager.storages)))
+        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.READ),AccessManager.storages))
         if not is_authorized:
-            raise ValueError(f"Local path '{href}' is not readable")
+            raise ValueError(f"Path '{href}' is not readable")
 
     @staticmethod
     def push(href: str, dst: str):
@@ -99,9 +97,10 @@ class AccessManager:
         Push a file from a local storage to write it in a storage.
         If the destination storage is local, then it is a copy. Otherwise it is an upload.
         """
-        storage = AccessManager.resolve_storage(dst)
-        AccessManager.check_local_path_readable(href)
+        AccessManager.check_path_readable(href)
+        AccessManager.check_path_writable(dst)
 
+        storage = AccessManager.resolve_storage(dst)
         storage.push(href, dst)
 
     @staticmethod
@@ -110,9 +109,10 @@ class AccessManager:
         Pulls a file from a storage to write it in the local storage.
         If the input storage is local, then it is a copy. Otherwise it is a download.
         """
-        storage = AccessManager.resolve_storage(href)
-        AccessManager.check_local_path_writable(dst)
+        AccessManager.check_path_readable(href)
+        AccessManager.check_path_writable(dst)
 
+        storage = AccessManager.resolve_storage(href)
         storage.pull(href, dst)
 
     @staticmethod

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -143,7 +143,6 @@ class AccessManager:
     @staticmethod
     def get_rasterio_session(href: str):
         storage = AccessManager.resolve_storage(href)
-        AccessManager.check_path_readable(href)
         return storage.get_rasterio_session(href)
 
     @staticmethod

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -49,7 +49,7 @@ class AccessManager:
             map(lambda s: s.is_path_authorized(tmp_dir, AccessType.WRITE),
                 filter(lambda s: s.storage_configuration.type == "file", AccessManager.storages)))
         if not is_tmp_dir_authorized:
-            raise ValueError("The given tmp_dir is not part of any defined FileStorage with WRITE authorization")
+            raise PermissionError("The given tmp_dir is not part of any defined FileStorage with WRITE authorization")
 
         AccessManager.tmp_dir = tmp_dir
 
@@ -80,7 +80,7 @@ class AccessManager:
         """
         is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.WRITE),AccessManager.storages))
         if not is_authorized:
-            raise ValueError(f"Path '{href}' is not writable")
+            raise PermissionError(f"Path '{href}' is not writable")
 
     @staticmethod
     def check_path_readable(href: str):
@@ -89,7 +89,7 @@ class AccessManager:
         """
         is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.READ),AccessManager.storages))
         if not is_authorized:
-            raise ValueError(f"Path '{href}' is not readable")
+            raise PermissionError(f"Path '{href}' is not readable")
 
     @staticmethod
     def push(href: str, dst: str):
@@ -264,14 +264,14 @@ class AccessManager:
                 for f in AccessManager.listdir(href):
                     folder_size += AccessManager.get_size(f.path)
                 return folder_size
-        raise ValueError(f"Given href does not exist {href}")
+        raise FileNotFoundError(f"Given href does not exist: {href}")
 
     @staticmethod
     def listdir(href: str) -> list[File]:
         storage = AccessManager.resolve_storage(href)
 
         if not storage.is_dir(href):
-            raise ValueError("Given href does not point to a directory ({})".format(href))
+            raise NotADirectoryError(f"Given href does not point to a directory: {href}")
 
         return storage.listdir(href)
 

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -9,6 +9,7 @@ from pydantic import Field
 from aias_common.access.configuration import AccessManagerSettings
 from aias_common.access.file import File
 from aias_common.access.logger import Logger
+from aias_common.access.storages.abstract import AbstractStorage
 from aias_common.access.storages.file import AccessType, FileStorage
 from aias_common.access.storages.gs import GoogleStorage
 from aias_common.access.storages.http import HttpStorage
@@ -23,7 +24,9 @@ LOGGER = Logger.logger
 class AccessManager:
     storages: list[AnyStorage]
     tmp_dir: str
-
+    cache_ttl: int = 60 * 60 * 24
+    cache_size = 1024
+    
     @staticmethod
     def init(ams: AccessManagerSettings):
         LOGGER.info("Initializing storages Access Manager")
@@ -65,7 +68,18 @@ class AccessManager:
                     return s
             except Exception:
                 ...
-        raise NotImplementedError(f"Storage for {href} is not configured")
+        raise PermissionError(f"Storage for {href} is not configured")
+
+    @staticmethod
+    def get_local_storage() -> FileStorage:
+        """
+        Based on the defined storages, returns the one that is a file storage
+        """
+
+        for s in AccessManager.storages:
+            if s.get_configuration().is_local:
+                return s
+        raise Exception("No local storage configured")
 
     @staticmethod
     def get_storage_parameters(href: str):
@@ -78,8 +92,7 @@ class AccessManager:
         """
         Checks that the path is a writable path for at least one of the file storages
         """
-        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.WRITE),AccessManager.storages))
-        if not is_authorized:
+        if not AccessManager.resolve_storage(href=href).is_path_authorized(href, AccessType.WRITE):
             raise PermissionError(f"Path '{href}' is not writable")
 
     @staticmethod
@@ -87,8 +100,7 @@ class AccessManager:
         """
         Checks that the path is a readable path for at least one of the file storages
         """
-        is_authorized = any(map(lambda s: s.is_path_authorized(href, AccessType.READ),AccessManager.storages))
-        if not is_authorized:
+        if not AccessManager.resolve_storage(href=href).is_path_authorized(href, AccessType.READ):
             raise PermissionError(f"Path '{href}' is not readable")
 
     @staticmethod
@@ -97,8 +109,10 @@ class AccessManager:
         Push a file from a local storage to write it in a storage.
         If the destination storage is local, then it is a copy. Otherwise it is an upload.
         """
-        AccessManager.check_path_readable(href)
-        AccessManager.check_path_writable(dst)
+        # Check that href is local
+        scheme = urlparse(href).scheme
+        if scheme != "" and scheme != "file":
+            raise ValueError("Source file to upload must be on the local filesystem")
 
         storage = AccessManager.resolve_storage(dst)
         storage.push(href, dst)
@@ -109,42 +123,26 @@ class AccessManager:
         Pulls a file from a storage to write it in the local storage.
         If the input storage is local, then it is a copy. Otherwise it is a download.
         """
-        AccessManager.check_path_readable(href)
-        AccessManager.check_path_writable(dst)
+        # Check that dst is local
+        scheme = urlparse(dst).scheme
+        if scheme != "" and scheme != "file":
+            raise ValueError("Destination must be on the local filesystem")
 
         storage = AccessManager.resolve_storage(href)
         storage.pull(href, dst)
 
     @staticmethod
-    def __http_to_s3__(href: str):
-        url = urlparse(href)
-        components = list(url[:])
-        if len(components) == 5:
-            components.append('')
-        components[0] = "s3"
-        components[1] = ""
-        components[2] = components[2].removeprefix("/")
-        s3url = urlunparse(tuple(components))
-        return s3url
-
-    @staticmethod
-    @contextmanager
     def stream(href: str):
-        import smart_open
         """
         Reads the content of a file in a storage without downloading it.
         """
-        params = AccessManager.get_storage_parameters(href)
-        if AccessManager.resolve_storage(href).get_configuration().type.lower() == "s3":
-            href = AccessManager.__http_to_s3__(href)
-        with smart_open.open(href, "rb", transport_params=params) as f:
-            yield f
+        yield AccessManager.resolve_storage(href=href).stream(href)
 
     @staticmethod
     def get_rasterio_session(href: str):
         storage = AccessManager.resolve_storage(href)
-
-        return storage.get_rasterio_session()
+        AccessManager.check_path_readable(href)
+        return storage.get_rasterio_session(href)
 
     @staticmethod
     def exists(href: str) -> bool:
@@ -228,11 +226,8 @@ class AccessManager:
 
     @staticmethod
     def clean(href: str):
-        try:
-            storage = AccessManager.resolve_storage(href)
-            storage.clean(href)  # !DELETE!
-        except Exception:
-            LOGGER.warning(f"Unable to remove file {href}")
+        storage = AccessManager.resolve_storage(href)
+        storage.clean(href)  # !DELETE!
 
     @staticmethod
     def zip(href: str, zip_path: str):
@@ -276,12 +271,12 @@ class AccessManager:
         return storage.listdir(href)
 
     @staticmethod
-    def get_last_modification_time(href: str):
+    def get_last_modification_time(href: str) -> float | None:
         storage = AccessManager.resolve_storage(href)
         return storage.get_last_modification_time(href)
 
     @staticmethod
-    def get_creation_time(href: str):
+    def get_creation_time(href: str) -> float | None:
         storage = AccessManager.resolve_storage(href)
         return storage.get_creation_time(href)
 

--- a/python/aias_common/access/manager.py
+++ b/python/aias_common/access/manager.py
@@ -132,11 +132,13 @@ class AccessManager:
         storage.pull(href, dst)
 
     @staticmethod
+    @contextmanager
     def stream(href: str):
         """
         Reads the content of a file in a storage without downloading it.
         """
-        yield AccessManager.resolve_storage(href=href).stream(href)
+        with AccessManager.resolve_storage(href=href).stream(href) as f:
+            yield f
 
     @staticmethod
     def get_rasterio_session(href: str):

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import os
 from abc import ABC, abstractmethod
+from typing import Callable
 
 from aias_common.access.configuration import AnyStorageConfiguration, AccessType
 from aias_common.access.file import File
@@ -19,7 +20,7 @@ class AbstractStorage(ABC):
     def __init__(self, storage_configuration: AnyStorageConfiguration):
         self.storage_configuration = storage_configuration
 
-    def _check_read_write_wrapper(self, storage, attr, index: int, action: AccessType):
+    def _check_read_write_wrapper(self, fct: Callable, index: int, action: AccessType):
         """Checks whether the action is permitted on the specified path before calling the function.
 
         Args:
@@ -32,13 +33,13 @@ class AbstractStorage(ABC):
             if len(kwargs) > 0:
                 LOGGER.warning("Dangerous call: positional arguments only should be used on {}, found: {}".format(self.__class__.__name__, kwargs))
             href = args[index]
-            if storage.is_path_authorized(href, action):
-                return attr(*args, **kwargs)
+            if self.is_path_authorized(href, action):
+                return fct(*args, **kwargs)
             LOGGER.error("{} on {} is not permitted on {}".format(action.value, self.to_string(), href))
             raise PermissionError("{} access on {} is not permitted on {}".format(action.value, href, self.to_string()))
         return wrapper
 
-    def __getattribute__(self, name):
+    def __getattribute__(self, name: str):
         """Intercepts calls to public methods to check read/write permissions before executing them.
 
         Args:
@@ -50,23 +51,23 @@ class AbstractStorage(ABC):
         Returns:
             _type_: The method being accessed
         """
-        attr = object.__getattribute__(self, name)
-        if callable(attr) and not name.startswith("_"):
+        fct = object.__getattribute__(self, name)
+        if callable(fct) and not name.startswith("_"):
             match name:
                 case "get_matching_s3_objects" | "is_dir" | "is_file" | "exists" | "listdir" | "get_file_size" | "get_rasterio_session" | "get_last_modification_time" | "get_creation_time" | "dirname" | "gdal_transform_href_vsi" | "get_gdal_src" | "get_gdal_info" | "stream":
-                    return self._check_read_write_wrapper(self, attr, 0, AccessType.READ)
+                    return self._check_read_write_wrapper(fct, 0, AccessType.READ)
                 case "makedir" | "clean":
-                    return self._check_read_write_wrapper(self, attr, 0, AccessType.WRITE)
+                    return self._check_read_write_wrapper(fct, 0, AccessType.WRITE)
                 case "pull":
-                    return self._check_read_write_wrapper(self, attr, 0, AccessType.READ)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 1, AccessType.WRITE)
+                    return self._check_read_write_wrapper(fct, 0, AccessType.READ)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 1, AccessType.WRITE)
                 case "push":
-                    return self._check_read_write_wrapper(self, attr, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
+                    return self._check_read_write_wrapper(fct, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
                 case "push_file_obj":
-                    return self._check_read_write_wrapper(self, attr, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
+                    return self._check_read_write_wrapper(fct, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
                 case _:
                     if name not in AbstractStorage.DO_NOT_PROTECT_METHODS:
                         raise Exception("Invalid implementation {} of AbstractStorage: method {} is public and not protected for READ/WRITE permission check.".format(self.__class__.__name__, name))
-        return attr
+        return fct
 
     def get_authorized_pathes(self, href: str, action: AccessType) -> list[str]:
         """ Returns the list of authorized pathes for the specified action, if the href is supported by the storage.

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -207,7 +207,8 @@ class AbstractStorage(ABC):
         Args:
             href(str): The href to delete
         """
-        ...
+        if not self.is_path_authorized(href, AccessType.WRITE):
+            raise PermissionError(f'The desired path ({href}) is not authorized to write (for deletion)')
 
     @abstractmethod
     def get_gdal_stream_options(self) -> dict:

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from aias_common.access.configuration import AnyStorageConfiguration, AccessType
 from aias_common.access.file import File
-from aias_common.access.storages.utils import remote_path_starts_with
 from aias_common.access.logger import Logger
 from urllib.parse import urlparse, urlunparse
 

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -1,19 +1,61 @@
+from contextlib import contextmanager
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from urllib.parse import urlparse
 
 from aias_common.access.configuration import AnyStorageConfiguration, AccessType
 from aias_common.access.file import File
 from aias_common.access.storages.utils import remote_path_starts_with
+from aias_common.access.logger import Logger
+from urllib.parse import urlparse, urlunparse
+
+LOGGER = Logger.logger
 
 
 class AbstractStorage(ABC):
     cache_tt = 60 * 5
     cache_size = 2048
+    DO_NOT_PROTECT_METHODS = ["is_path_authorized", "get_configuration", "get_storage_parameters", "to_string", "supports"]
 
     def __init__(self, storage_configuration: AnyStorageConfiguration):
         self.storage_configuration = storage_configuration
+
+    def _check_read_write_wrapper(self, storage, attr, index, action):
+        def wrapper(*args, **kwargs):
+            href = args[index]
+            if storage.is_path_authorized(href, action):
+                return attr(*args, **kwargs)
+            LOGGER.warning("{} on {} is not permitted on {}".format(action.value, self.to_string(), href))
+            raise PermissionError("{} access on {} is not permitted on {}".format(action.value, href, self.to_string()))
+        return wrapper
+
+    def __getattribute__(self, name):
+        attr = object.__getattribute__(self, name)
+        if callable(attr) and not name.startswith("_"):
+            match name:
+                case "is_dir" | "is_file" | "exists" | "listdir" | "get_file_size" | "get_rasterio_session" | "get_last_modification_time" | "get_creation_time" | "dirname" | "get_gdal_stream_options" | "gdal_transform_href_vsi" | "get_gdal_src" | "get_gdal_info" | "stream":
+                    return self._check_read_write_wrapper(self, attr, 0, AccessType.READ)
+                case "makedir" | "clean":
+                    return self._check_read_write_wrapper(self, attr, 0, AccessType.WRITE)
+                case "pull":
+                    return self._check_read_write_wrapper(self, attr, 0, AccessType.READ)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 1, AccessType.WRITE)
+                case "push":
+                    return self._check_read_write_wrapper(self, attr, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
+                case "push_file_obj":
+                    return self._check_read_write_wrapper(self, attr, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
+                case _:
+                    if name not in AbstractStorage.DO_NOT_PROTECT_METHODS:
+                        raise Exception("Invalid implementation {} of AbstractStorage: method {} is public and not protected for READ/WRITE permission check.".format(self.__class__.__name__, name))
+        return attr
+
+    @abstractmethod
+    def to_string(self) -> str:
+        """Returns the storage to_string description
+
+        Returns:
+            str: a description that can be displayed
+        """
+        ...
 
     @abstractmethod
     def get_configuration(self) -> AnyStorageConfiguration:
@@ -25,11 +67,12 @@ class AbstractStorage(ABC):
         ...
 
     @abstractmethod
-    def get_storage_parameters(self) -> dict:
+    def get_storage_parameters(self, href) -> dict:
         """Based on the type of storage and its characteristics, gives storage-specific parameters to use to access data
         """
         ...
 
+    @abstractmethod
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
         """Check whether a given action is permitted on the specified path.
 
@@ -40,19 +83,6 @@ class AbstractStorage(ABC):
         Returns:
             bool: True if the action is authorized, False otherwise
         """
-        # Get the list of accessible paths for the given action
-        if action == AccessType.WRITE:
-            paths = self.get_configuration().writable_paths
-        if action == AccessType.READ:
-            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
-        # Check if the given path is a sub-path of the authorized paths
-        if self.storage_configuration.is_local:
-            is_authorized = any(list(map(lambda p: Path(href).is_relative_to(Path(p)), paths)))
-        else:
-            is_authorized =  any(list(map(lambda p: remote_path_starts_with(path=href, prefix=p), paths)))
-        return is_authorized
-
-
 
     @abstractmethod
     def supports(self, href: str) -> bool:
@@ -79,7 +109,7 @@ class AbstractStorage(ABC):
         ...
 
     @abstractmethod
-    def get_rasterio_session(self) -> dict:
+    def get_rasterio_session(self, href) -> dict:
         """Return a rasterio Session and potential variables to access data remotely
 
         Args:
@@ -98,10 +128,7 @@ class AbstractStorage(ABC):
             href (str): File to fetch
             dst (str): Destination of the file
         """
-        # Check that dst is local
-        scheme = urlparse(dst).scheme
-        if scheme != "" and scheme != "file":
-            raise ValueError("Destination must be on the local filesystem")
+        ...
 
     @abstractmethod
     def push(self, href: str, dst: str, content_type: str | None = None):
@@ -111,10 +138,7 @@ class AbstractStorage(ABC):
             href (str): File to upload
             dst (str): Destination of the file
         """
-        # Check that href is local
-        scheme = urlparse(href).scheme
-        if scheme != "" and scheme != "file":
-            raise ValueError("Source file to upload must be on the local filesystem")
+        ...
 
     @abstractmethod
     def is_file(self, href: str) -> bool:
@@ -159,7 +183,7 @@ class AbstractStorage(ABC):
         ...
 
     @abstractmethod
-    def get_last_modification_time(self, href: str) -> float:
+    def get_last_modification_time(self, href: str) -> float | None:
         """Returns the last modification time of the specified href
 
         Args:
@@ -171,7 +195,7 @@ class AbstractStorage(ABC):
         ...
 
     @abstractmethod
-    def get_creation_time(self, href: str) -> float:
+    def get_creation_time(self, href: str) -> float | None:
         """Returns the creation time of the specified href
 
         Args:
@@ -207,8 +231,7 @@ class AbstractStorage(ABC):
         Args:
             href(str): The href to delete
         """
-        if not self.is_path_authorized(href, AccessType.WRITE):
-            raise PermissionError(f'The desired path ({href}) is not authorized to write (for deletion)')
+        ...
 
     @abstractmethod
     def get_gdal_stream_options(self) -> dict:
@@ -248,3 +271,23 @@ class AbstractStorage(ABC):
 
         with gdal.config_options(self.get_gdal_stream_options()):
             return gdal.Info(self.gdal_transform_href_vsi(href), options=gdal_options)
+
+    def __http_to_s3__(self, href: str):
+        url = urlparse(href)
+        components = list(url[:])
+        if len(components) == 5:
+            components.append('')
+        components[0] = "s3"
+        components[1] = ""
+        components[2] = components[2].removeprefix("/")
+        s3url = urlunparse(tuple(components))
+        return s3url
+
+    @contextmanager
+    def stream(self, href: str):
+        import smart_open
+        params = self.get_storage_parameters()
+        if self.get_configuration().type.lower() == "s3":
+            href = self.__http_to_s3__(href)
+        with smart_open.open(href, "rb", transport_params=params) as f:
+            yield f

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -15,13 +15,15 @@ LOGGER = Logger.logger
 class AbstractStorage(ABC):
     cache_tt = 60 * 5
     cache_size = 2048
-    DO_NOT_PROTECT_METHODS = ["is_path_authorized", "get_configuration", "get_storage_parameters", "to_string", "supports"]
+    DO_NOT_PROTECT_METHODS = ["is_path_authorized", "get_configuration", "get_storage_parameters", "to_string", "supports", "get_full_href", "get_gdal_stream_options"]
 
     def __init__(self, storage_configuration: AnyStorageConfiguration):
         self.storage_configuration = storage_configuration
 
     def _check_read_write_wrapper(self, storage, attr, index, action):
         def wrapper(*args, **kwargs):
+            if len(kwargs) > 0:
+                LOGGER.warning("Dangerous call: positional arguments only should be used on {}, found: {}".format(self.__class__.__name__, kwargs))
             href = args[index]
             if storage.is_path_authorized(href, action):
                 return attr(*args, **kwargs)
@@ -33,7 +35,7 @@ class AbstractStorage(ABC):
         attr = object.__getattribute__(self, name)
         if callable(attr) and not name.startswith("_"):
             match name:
-                case "is_dir" | "is_file" | "exists" | "listdir" | "get_file_size" | "get_rasterio_session" | "get_last_modification_time" | "get_creation_time" | "dirname" | "get_gdal_stream_options" | "gdal_transform_href_vsi" | "get_gdal_src" | "get_gdal_info" | "stream":
+                case "get_matching_s3_objects" | "is_dir" | "is_file" | "exists" | "listdir" | "get_file_size" | "get_rasterio_session" | "get_last_modification_time" | "get_creation_time" | "dirname" | "gdal_transform_href_vsi" | "get_gdal_src" | "get_gdal_info" | "stream":
                     return self._check_read_write_wrapper(self, attr, 0, AccessType.READ)
                 case "makedir" | "clean":
                     return self._check_read_write_wrapper(self, attr, 0, AccessType.WRITE)
@@ -45,7 +47,7 @@ class AbstractStorage(ABC):
                     return self._check_read_write_wrapper(self, attr, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
                 case _:
                     if name not in AbstractStorage.DO_NOT_PROTECT_METHODS:
-                        raise Exception("Invalid implementation {} of AbstractStorage: method {} is public and not protected for READ/WRITE permission check.".format(self.__class__.__name__, name))
+                        raise Exception("Invalid implementation {} of AbstractStorage: method {} is public and not protected for READ/WRITE permission check.".format(self.__class__.__name__, name))
         return attr
 
     @abstractmethod

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -1,9 +1,11 @@
 import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from urllib.parse import urlparse
 
-from aias_common.access.configuration import AnyStorageConfiguration
+from aias_common.access.configuration import AnyStorageConfiguration, AccessType
 from aias_common.access.file import File
+from aias_common.access.storages.utils import remote_path_starts_with
 
 
 class AbstractStorage(ABC):
@@ -25,11 +27,32 @@ class AbstractStorage(ABC):
     @abstractmethod
     def get_storage_parameters(self) -> dict:
         """Based on the type of storage and its characteristics, gives storage-specific parameters to use to access data
+        """
+        ...
+
+    def is_path_authorized(self, href: str, action: AccessType) -> bool:
+        """Check whether a given action is permitted on the specified path.
 
         Args:
             href (str): Href of the file to consult
+            action (AccessType): Action to check permission for, on the specified path
+
+        Returns:
+            bool: True if the action is authorized, False otherwise
         """
-        ...
+        # Get the list of accessible paths for the given action
+        if action == AccessType.WRITE:
+            paths = self.get_configuration().writable_paths
+        if action == AccessType.READ:
+            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+        # Check if the given path is a sub-path of the authorized paths
+        if self.storage_configuration.is_local:
+            is_authorized = any(list(map(lambda p: Path(href).is_relative_to(Path(p)), paths)))
+        else:
+            is_authorized =  any(list(map(lambda p: remote_path_starts_with(path=href, prefix=p), paths)))
+        return is_authorized
+
+
 
     @abstractmethod
     def supports(self, href: str) -> bool:

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -8,6 +8,8 @@ from aias_common.access.file import File
 from aias_common.access.logger import Logger
 from urllib.parse import urlparse, urlunparse
 
+from aias_common.access.storages.path_helper import http_href_to_s3
+
 LOGGER = Logger.logger
 
 
@@ -19,18 +21,37 @@ class AbstractStorage(ABC):
     def __init__(self, storage_configuration: AnyStorageConfiguration):
         self.storage_configuration = storage_configuration
 
-    def _check_read_write_wrapper(self, storage, attr, index, action):
+    def _check_read_write_wrapper(self, storage, attr, index: int, action: AccessType):
+        """Checks whether the action is permitted on the specified path before calling the function.
+
+        Args:
+            storage (AbstractStorage): Storage to use to check permissions
+            attr (_type_): function to call
+            index (int): index of the href in the function's parameters
+            action (AccessType): Action to check permission for, on the specified path
+        """
         def wrapper(*args, **kwargs):
             if len(kwargs) > 0:
                 LOGGER.warning("Dangerous call: positional arguments only should be used on {}, found: {}".format(self.__class__.__name__, kwargs))
             href = args[index]
             if storage.is_path_authorized(href, action):
                 return attr(*args, **kwargs)
-            LOGGER.warning("{} on {} is not permitted on {}".format(action.value, self.to_string(), href))
+            LOGGER.error("{} on {} is not permitted on {}".format(action.value, self.to_string(), href))
             raise PermissionError("{} access on {} is not permitted on {}".format(action.value, href, self.to_string()))
         return wrapper
 
     def __getattribute__(self, name):
+        """Intercepts calls to public methods to check read/write permissions before executing them.
+
+        Args:
+            name (str): Name of the method being called
+
+        Raises:
+            Exception: If a public method is not protected for read/write permission check
+
+        Returns:
+            _type_: The method being accessed
+        """
         attr = object.__getattribute__(self, name)
         if callable(attr) and not name.startswith("_"):
             match name:
@@ -48,6 +69,28 @@ class AbstractStorage(ABC):
                     if name not in AbstractStorage.DO_NOT_PROTECT_METHODS:
                         raise Exception("Invalid implementation {} of AbstractStorage: method {} is public and not protected for READ/WRITE permission check.".format(self.__class__.__name__, name))
         return attr
+
+
+    def __get_authorized_pathes(self, href: str, action: AccessType) -> list[str]:
+        """ Returns the list of authorized pathes for the specified action, if the href is supported by the storage.
+
+        Args:
+            href (str): Href of the resource to consult
+            action (AccessType): Action to check permission for, on the specified path
+
+        Raises:
+            PermissionError: If the href is not supported by the storage
+
+        Returns:
+            list[str]: The list of authorized pathes for the specified action
+        """
+        if not self.supports(href=href):
+            raise PermissionError("{} not on {}".format(self.to_string(), href))
+        if action == AccessType.WRITE:
+            return self.get_configuration().writable_paths
+        else:
+            return list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+
 
     @abstractmethod
     def to_string(self) -> str:
@@ -110,7 +153,7 @@ class AbstractStorage(ABC):
         ...
 
     @abstractmethod
-    def get_rasterio_session(self, href) -> dict:
+    def get_rasterio_session(self, href: str) -> dict:
         """Return a rasterio Session and potential variables to access data remotely
 
         Args:
@@ -273,22 +316,12 @@ class AbstractStorage(ABC):
         with gdal.config_options(self.get_gdal_stream_options()):
             return gdal.Info(self.gdal_transform_href_vsi(href), options=gdal_options)
 
-    def __http_to_s3__(self, href: str):
-        url = urlparse(href)
-        components = list(url[:])
-        if len(components) == 5:
-            components.append('')
-        components[0] = "s3"
-        components[1] = ""
-        components[2] = components[2].removeprefix("/")
-        s3url = urlunparse(tuple(components))
-        return s3url
 
     @contextmanager
     def stream(self, href: str):
         import smart_open
         params = self.get_storage_parameters()
         if self.get_configuration().type.lower() == "s3":
-            href = self.__http_to_s3__(href)
+            href = http_href_to_s3(href)
         with smart_open.open(href, "rb", transport_params=params) as f:
             yield f

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -1,12 +1,10 @@
 from contextlib import contextmanager
 import os
 from abc import ABC, abstractmethod
-from pathlib import Path
 
 from aias_common.access.configuration import AnyStorageConfiguration, AccessType
 from aias_common.access.file import File
 from aias_common.access.logger import Logger
-from urllib.parse import urlparse, urlunparse
 
 from aias_common.access.storages.path_helper import http_href_to_s3
 
@@ -16,7 +14,7 @@ LOGGER = Logger.logger
 class AbstractStorage(ABC):
     cache_tt = 60 * 5
     cache_size = 2048
-    DO_NOT_PROTECT_METHODS = ["is_path_authorized", "get_configuration", "get_storage_parameters", "to_string", "supports", "get_full_href", "get_gdal_stream_options"]
+    DO_NOT_PROTECT_METHODS = ["get_authorized_pathes", "is_path_authorized", "get_configuration", "get_storage_parameters", "to_string", "supports", "get_full_href", "get_gdal_stream_options"]
 
     def __init__(self, storage_configuration: AnyStorageConfiguration):
         self.storage_configuration = storage_configuration
@@ -70,8 +68,7 @@ class AbstractStorage(ABC):
                         raise Exception("Invalid implementation {} of AbstractStorage: method {} is public and not protected for READ/WRITE permission check.".format(self.__class__.__name__, name))
         return attr
 
-
-    def __get_authorized_pathes(self, href: str, action: AccessType) -> list[str]:
+    def get_authorized_pathes(self, href: str, action: AccessType) -> list[str]:
         """ Returns the list of authorized pathes for the specified action, if the href is supported by the storage.
 
         Args:
@@ -84,13 +81,10 @@ class AbstractStorage(ABC):
         Returns:
             list[str]: The list of authorized pathes for the specified action
         """
-        if not self.supports(href=href):
-            raise PermissionError("{} not on {}".format(self.to_string(), href))
         if action == AccessType.WRITE:
             return self.get_configuration().writable_paths
         else:
             return list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
-
 
     @abstractmethod
     def to_string(self) -> str:
@@ -111,7 +105,7 @@ class AbstractStorage(ABC):
         ...
 
     @abstractmethod
-    def get_storage_parameters(self, href) -> dict:
+    def get_storage_parameters(self) -> dict:
         """Based on the type of storage and its characteristics, gives storage-specific parameters to use to access data
         """
         ...

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -76,13 +76,11 @@ class FileStorage(AbstractStorage):
         return os.path.dirname(os.path.abspath(href))
 
     def clean(self, href: str):
-        if self.is_path_authorized(href, AccessType.WRITE):
-            if self.is_dir(href):
-                shutil.rmtree(href)  # !DELETE!
-            else:
-                os.remove(href)  # !DELETE!
+        super().clean(href=href)
+        if self.is_dir(href):
+            shutil.rmtree(href)  # !DELETE!
         else:
-            raise ValueError("The given path is read-only")
+            os.remove(href)  # !DELETE!
 
     def get_gdal_stream_options(self):
         return {}

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -66,7 +66,7 @@ class FileStorage(AbstractStorage):
 
     def makedir(self, href: str, strict=False):
         if not self.is_path_authorized(href, AccessType.WRITE):
-            raise ValueError('The desired folder is not authorized')
+            raise PermissionError(f'The desired folder path is not authorized to write: {href}')
 
         if not self.exists(href) or strict:
             os.makedirs(href)

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -32,17 +32,13 @@ class FileStorage(AbstractStorage):
     def exists(self, href: str):
         return Path(href).exists()
 
-    def get_rasterio_session(self, href):
+    def get_rasterio_session(self, href: str):
         return {}
 
     def pull(self, href: str, dst: str):
-        super().pull(href, dst)
-
         shutil.copy(href, dst)
 
     def push(self, href: str, dst: str, content_type: str | None = None):
-        super().push(href, dst)
-
         shutil.copy(href, dst)
 
     def is_file(self, href: str):
@@ -83,7 +79,6 @@ class FileStorage(AbstractStorage):
         return os.path.dirname(os.path.abspath(href))
 
     def clean(self, href: str):
-        super().clean(href=href)
         if self.is_dir(href):
             shutil.rmtree(href)  # !DELETE!
         else:

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -28,26 +28,13 @@ class FileStorage(AbstractStorage):
     def get_rasterio_session(self):
         return {}
 
-    def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        if action == AccessType.WRITE:
-            paths = self.get_configuration().writable_paths
-        if action == AccessType.READ:
-            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
-        return any(list(map(lambda p: os.path.commonpath([p, href]) == p, paths)))
-
     def pull(self, href: str, dst: str):
         super().pull(href, dst)
-
-        if not self.is_path_authorized(dst, AccessType.WRITE):
-            raise ValueError('The desired output path is not authorized')
 
         shutil.copy(href, dst)
 
     def push(self, href: str, dst: str, content_type: str | None = None):
         super().push(href, dst)
-
-        if not self.is_path_authorized(dst, AccessType.WRITE):
-            raise ValueError('The desired output path is not authorized')
 
         shutil.copy(href, dst)
 
@@ -65,7 +52,8 @@ class FileStorage(AbstractStorage):
 
     def __to_file__(self, base: str, name: str):
         path = os.sep.join([base.removesuffix("/"), name])
-        f = File(name=name, path=path, is_dir=os.path.isdir(path), last_modification_date=os.path.getmtime(path), creation_date=os.path.getctime(path))
+        f = File(name=name, path=path, is_dir=os.path.isdir(path), last_modification_date=os.path.getmtime(path),
+                 creation_date=os.path.getctime(path))
         if f.is_dir:
             f.path = f.path.removesuffix("/") + "/"
         return f

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -11,6 +11,16 @@ from aias_common.access.storages.abstract import AbstractStorage
 
 class FileStorage(AbstractStorage):
 
+    def to_string(self) -> str:
+        return "file system storage"
+
+    def is_path_authorized(self, href: str, action: AccessType) -> bool:
+        if action == AccessType.WRITE:
+            paths = self.get_configuration().writable_paths
+        else:
+            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+        return any(list(map(lambda p: Path(href).is_relative_to(Path(p)), paths)))
+
     def get_configuration(self) -> FileStorageConfiguration:
         assert isinstance(self.storage_configuration, FileStorageConfiguration)
         return self.storage_configuration
@@ -25,7 +35,7 @@ class FileStorage(AbstractStorage):
     def exists(self, href: str):
         return Path(href).exists()
 
-    def get_rasterio_session(self):
+    def get_rasterio_session(self, href):
         return {}
 
     def pull(self, href: str, dst: str):
@@ -58,10 +68,10 @@ class FileStorage(AbstractStorage):
             f.path = f.path.removesuffix("/") + "/"
         return f
 
-    def get_last_modification_time(self, href: str):
+    def get_last_modification_time(self, href: str) -> float | None:
         return os.path.getmtime(href)
 
-    def get_creation_time(self, href: str):
+    def get_creation_time(self, href: str) -> float | None:
         return os.path.getctime(href)
 
     def makedir(self, href: str, strict=False):

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -15,14 +15,14 @@ class FileStorage(AbstractStorage):
         return "file system storage"
 
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        paths = self.__get_authorized_pathes(href, action)
+        paths = self.get_authorized_pathes(href, action)
         return any(list(map(lambda p: Path(href).is_relative_to(Path(p)), paths)))
 
     def get_configuration(self) -> FileStorageConfiguration:
         assert isinstance(self.storage_configuration, FileStorageConfiguration)
         return self.storage_configuration
 
-    def get_storage_parameters(self):
+    def get_storage_parameters(self) -> dict:
         return {}
 
     def supports(self, href: str):

--- a/python/aias_common/access/storages/file.py
+++ b/python/aias_common/access/storages/file.py
@@ -15,10 +15,7 @@ class FileStorage(AbstractStorage):
         return "file system storage"
 
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        if action == AccessType.WRITE:
-            paths = self.get_configuration().writable_paths
-        else:
-            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+        paths = self.__get_authorized_pathes(href, action)
         return any(list(map(lambda p: Path(href).is_relative_to(Path(p)), paths)))
 
     def get_configuration(self) -> FileStorageConfiguration:

--- a/python/aias_common/access/storages/gs.py
+++ b/python/aias_common/access/storages/gs.py
@@ -15,10 +15,7 @@ class GoogleStorage(AbstractStorage):
         return "google cloud object storage on bucket {}".format(self.get_configuration().bucket)
 
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        if action == AccessType.WRITE:
-            paths = self.get_configuration().writable_paths
-        else:
-            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+        paths = self.__get_authorized_pathes(href, action)
 
         prefix = "gs://" + self.get_configuration().bucket.removeprefix("/").removesuffix("/")
         h = href.removesuffix("/") + "/"
@@ -63,7 +60,7 @@ class GoogleStorage(AbstractStorage):
     def exists(self, href: str):
         return self.is_file(href) or self.is_dir(href)
 
-    def get_rasterio_session(self, href):
+    def get_rasterio_session(self, href: str):
         import rasterio.session
 
         params = {

--- a/python/aias_common/access/storages/gs.py
+++ b/python/aias_common/access/storages/gs.py
@@ -15,7 +15,7 @@ class GoogleStorage(AbstractStorage):
         return "google cloud object storage on bucket {}".format(self.get_configuration().bucket)
 
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        paths = self.__get_authorized_pathes(href, action)
+        paths = self.get_authorized_pathes(href, action)
 
         prefix = "gs://" + self.get_configuration().bucket.removeprefix("/").removesuffix("/")
         h = href.removesuffix("/") + "/"
@@ -25,7 +25,7 @@ class GoogleStorage(AbstractStorage):
         assert isinstance(self.storage_configuration, GoogleStorageConfiguration)
         return self.storage_configuration
 
-    def get_storage_parameters(self):
+    def get_storage_parameters(self) -> dict:
         if self.get_configuration().is_anon_client:
             client = Client.create_anonymous_client()
         else:

--- a/python/aias_common/access/storages/gs.py
+++ b/python/aias_common/access/storages/gs.py
@@ -1,7 +1,7 @@
 import os
 from urllib.parse import urlparse, urlunparse
 
-from aias_common.access.configuration import GoogleStorageConfiguration
+from aias_common.access.configuration import AccessType, GoogleStorageConfiguration
 from aias_common.access.file import File
 from aias_common.access.storages.abstract import AbstractStorage
 from fastapi_utilities import ttl_lru_cache
@@ -10,6 +10,19 @@ from google.oauth2 import service_account
 
 
 class GoogleStorage(AbstractStorage):
+
+    def to_string(self) -> str:
+        return "google cloud object storage on bucket {}".format(self.get_configuration().bucket)
+
+    def is_path_authorized(self, href: str, action: AccessType) -> bool:
+        if action == AccessType.WRITE:
+            paths = self.get_configuration().writable_paths
+        else:
+            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+
+        prefix = "gs://" + self.get_configuration().bucket.removeprefix("/").removesuffix("/")
+        h = href.removesuffix("/") + "/"
+        return any(list(map(lambda p: h.startswith("/".join([prefix, p.removeprefix("/") + "/"])), paths)))
 
     def get_configuration(self) -> GoogleStorageConfiguration:
         assert isinstance(self.storage_configuration, GoogleStorageConfiguration)
@@ -50,7 +63,7 @@ class GoogleStorage(AbstractStorage):
     def exists(self, href: str):
         return self.is_file(href) or self.is_dir(href)
 
-    def get_rasterio_session(self):
+    def get_rasterio_session(self, href):
         import rasterio.session
 
         params = {
@@ -121,14 +134,14 @@ class GoogleStorage(AbstractStorage):
     def listdir(self, href: str) -> list[File]:
         return self.__list_blobs(href.removesuffix("/") + "/")
 
-    def get_last_modification_time(self, href: str):
+    def get_last_modification_time(self, href: str) -> float | None:
         blob = self.__get_blob(href)
         if blob:
             mod_time = blob.updated
             return mod_time.timestamp() if mod_time is not None else 0
         return 0
 
-    def get_creation_time(self, href: str):
+    def get_creation_time(self, href: str) -> float | None:
         blob = self.__get_blob(href)
         if blob:
             creation_time = blob.time_created

--- a/python/aias_common/access/storages/http.py
+++ b/python/aias_common/access/storages/http.py
@@ -11,14 +11,7 @@ from aias_common.access.storages.utils import (requests_exists, requests_get,
 class HttpStorage(AbstractStorage):
 
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        if not self.supports(href=href):
-            raise PermissionError("{} not on {}".format(self.to_string(), href))
-
-        if action == AccessType.WRITE:
-            paths = self.get_configuration().writable_paths
-        else:
-            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
-
+        paths = self.__get_authorized_pathes(href, action)
         path = urlparse(href).path
         return any(list(map(lambda p: path.startswith(p.removesuffix("/") + "/"), paths)))
 
@@ -67,7 +60,6 @@ class HttpStorage(AbstractStorage):
 
     def get_last_modification_time(self, href: str) -> float | None:
         r = requests_head(href, self.get_configuration().headers)
-        print(r.headers)
         if r.headers.get("Last-Modified"):
             return time.mktime(time.strptime(r.headers.get("Last-Modified"), "%a, %d %b %Y %H:%M:%S %Z"))
         return None

--- a/python/aias_common/access/storages/http.py
+++ b/python/aias_common/access/storages/http.py
@@ -11,7 +11,7 @@ from aias_common.access.storages.utils import (requests_exists, requests_get,
 class HttpStorage(AbstractStorage):
 
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        paths = self.__get_authorized_pathes(href, action)
+        paths = self.get_authorized_pathes(href, action)
         path = urlparse(href).path
         return any(list(map(lambda p: path.startswith(p.removesuffix("/") + "/"), paths)))
 
@@ -22,7 +22,7 @@ class HttpStorage(AbstractStorage):
         assert isinstance(self.storage_configuration, HttpStorageConfiguration)
         return self.storage_configuration
 
-    def get_storage_parameters(self):
+    def get_storage_parameters(self) -> dict:
         return {"headers": self.get_configuration().headers}
 
     def supports(self, href: str):

--- a/python/aias_common/access/storages/http.py
+++ b/python/aias_common/access/storages/http.py
@@ -1,7 +1,7 @@
 import time
 from urllib.parse import urlparse
 
-from aias_common.access.configuration import HttpStorageConfiguration
+from aias_common.access.configuration import AccessType, HttpStorageConfiguration
 from aias_common.access.file import File
 from aias_common.access.storages.abstract import AbstractStorage
 from aias_common.access.storages.utils import (requests_exists, requests_get,
@@ -9,6 +9,21 @@ from aias_common.access.storages.utils import (requests_exists, requests_get,
 
 
 class HttpStorage(AbstractStorage):
+
+    def is_path_authorized(self, href: str, action: AccessType) -> bool:
+        if not self.supports(href=href):
+            raise PermissionError("{} not on {}".format(self.to_string(), href))
+
+        if action == AccessType.WRITE:
+            paths = self.get_configuration().writable_paths
+        else:
+            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+
+        path = urlparse(href).path
+        return any(list(map(lambda p: path.startswith(p.removesuffix("/") + "/"), paths)))
+
+    def to_string(self) -> str:
+        return "{} storage at {}".format(self.get_configuration().type, self.get_configuration().domain)
 
     def get_configuration(self) -> HttpStorageConfiguration:
         assert isinstance(self.storage_configuration, HttpStorageConfiguration)
@@ -20,13 +35,12 @@ class HttpStorage(AbstractStorage):
     def supports(self, href: str):
         scheme = urlparse(href).scheme
         netloc = urlparse(href).netloc
-
         return scheme == self.get_configuration().type and netloc == self.get_configuration().domain
 
     def exists(self, href: str):
         return requests_exists(href, self.get_configuration().headers)
 
-    def get_rasterio_session(self):
+    def get_rasterio_session(self, href):
         # Might not work
         return {}
 
@@ -51,11 +65,14 @@ class HttpStorage(AbstractStorage):
     def listdir(self, href: str) -> list[File]:
         raise NotImplementedError(f"It is not possible to list the content of a directory with {self.get_configuration().type} protocol")
 
-    def get_last_modification_time(self, href: str):
+    def get_last_modification_time(self, href: str) -> float | None:
         r = requests_head(href, self.get_configuration().headers)
-        return time.mktime(time.strptime(r.headers.get("Last-Modified"), "%a, %d %b %Y %H:%M:%S %Z"))
+        print(r.headers)
+        if r.headers.get("Last-Modified"):
+            return time.mktime(time.strptime(r.headers.get("Last-Modified"), "%a, %d %b %Y %H:%M:%S %Z"))
+        return None
 
-    def get_creation_time(self, href: str):
+    def get_creation_time(self, href: str) -> float | None:
         # There is no difference in HTTP(S) between last update and creation date
         return self.get_last_modification_time(href)
 

--- a/python/aias_common/access/storages/path_helper.py
+++ b/python/aias_common/access/storages/path_helper.py
@@ -1,0 +1,63 @@
+
+from urllib.parse import urlparse, urlunparse
+
+
+def noslash(txt: str) -> str:
+    """Remove leading and trailing slashes from the given text.
+
+    Args:
+        txt (str): The text.
+
+    Returns:
+        str: The text without leading and trailing slashes.
+    """    
+    return txt.removeprefix("/").removesuffix("/")
+
+
+def endslash(txt: str) -> str:
+    """Add a trailing slash to the given text if not present.
+
+    Args:
+        txt (str): The text.
+
+    Returns:
+        str: The text with a trailing slash.
+    """    
+    return txt.removesuffix("/") + "/"
+
+
+def http_href_to_s3(href: str) -> str:
+    """Generate an S3 href from an HTTP href
+
+    Args:
+        href (str): The HTTP href.
+
+    Returns:
+        str: The S3 href.
+    """ 
+    url = urlparse(href)
+    components = list(url[:])
+    if len(components) == 5:
+        components.append('')
+    components[0] = "s3"
+    components[1] = ""
+    components[2] = components[2].removeprefix("/")
+    s3url = urlunparse(tuple(components))
+    return s3url
+
+
+def join_pathes(*ps: str) -> str:
+    """Join multiple pathes ensuring there is exactly one '/' between them.
+
+    Returns:
+        str: The joined path.
+    """    
+    pathes: list[str] = list(filter(lambda p: p != "", ps))
+    if len(pathes) == 1:
+        return pathes[0]
+    if len(pathes) > 1:
+        pathes[0] = pathes[0].removesuffix("/")
+        pathes[-1] = pathes[-1].removeprefix("/")
+        for i in range(1, len(pathes) - 1):
+            pathes[i] = pathes[i].removeprefix("/").removesuffix("/")
+    return "/".join(pathes)

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -65,7 +65,7 @@ class S3Storage(AbstractStorage):
     def exists(self, href: str):
         return self.is_dir(href) or self.is_file(href)
 
-    def get_rasterio_session(self, href):
+    def get_rasterio_session(self, href: str):
         import rasterio.session
 
         params = {}

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from urllib.parse import urlparse, urlunparse
 
@@ -19,7 +20,7 @@ class S3Storage(AbstractStorage):
             paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
 
         prefix = "/".join([self.__noslash(self.get_configuration().endpoint), self.__noslash(self.get_configuration().bucket)])
-        h = self.__endslash(href)
+        h = self.__endslash(self.__noslash(href))
         return any(list(map(lambda p: h.startswith(self.__endslash("/".join([prefix, self.__noslash(p)]))), paths)))
 
     def __noslash(self, txt: str) -> str:
@@ -92,6 +93,12 @@ class S3Storage(AbstractStorage):
             )
 
         return params
+
+    def get_full_href(self, path: str):
+        if self.get_configuration().endpoint:
+            return self.get_configuration().endpoint + "/" + self.get_configuration().bucket + "/" + path.removeprefix("/")
+        else:
+            return "s3://" + self.get_configuration().bucket + "/" + path.removeprefix("/")
 
     def __get_href_key(self, href: str):
         return urlparse(href).path.removeprefix(f"/{self.get_configuration().bucket}").removeprefix("/").removesuffix("/") 
@@ -257,34 +264,27 @@ class S3Storage(AbstractStorage):
 
         return href
 
-    def get_matching_s3_objects(self, prefix="", suffix="", s3_client=None):
+    def get_matching_s3_objects(self, path, suffix="", s3_client=None):
 
+        prefix = self.__noslash(urlparse(path).path.removeprefix("/" + self.get_configuration().bucket))
+        LOGGER.debug("Search for objects in bucket %s with prefix %s and suffix %s", self.get_configuration().bucket, prefix, suffix)
         import botocore.client
         client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
         paginator = client.get_paginator("list_objects_v2")
 
         kwargs = {'Bucket': self.get_configuration().bucket}
+        kwargs["Prefix"] = prefix
 
-        # We can pass the prefix directly to the S3 API.  If the user has passed
-        # a tuple or list of prefixes, we go through them one by one.
-        if isinstance(prefix, str):
-            prefixes = (prefix, )
-        else:
-            prefixes = prefix
+        for page in paginator.paginate(**kwargs):
+            try:
+                contents = page["Contents"]
+            except KeyError:
+                break
 
-        for key_prefix in prefixes:
-            kwargs["Prefix"] = key_prefix
-
-            for page in paginator.paginate(**kwargs):
-                try:
-                    contents = page["Contents"]
-                except KeyError:
-                    break
-
-                for obj in contents:
-                    key = obj["Key"]
-                    if key.endswith(suffix):
-                        yield key
+            for obj in contents:
+                key = obj["Key"]
+                if key.endswith(suffix):
+                    yield key
 
     def get_matching_s3_keys(self, prefix="", suffix=""):
         for obj in self.get_matching_s3_objects(prefix, suffix):

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from urllib.parse import urlparse, urlunparse
 
@@ -8,7 +7,7 @@ from aias_common.access.logger import Logger
 from aias_common.access.storages.abstract import AbstractStorage
 from fastapi_utilities import ttl_lru_cache
 
-from aias_common.access.storages.path_helper import endslash, noslash
+from aias_common.access.storages.path_helper import endslash, join_pathes, noslash
 
 LOGGER = Logger.logger
 
@@ -16,12 +15,11 @@ LOGGER = Logger.logger
 class S3Storage(AbstractStorage):
 
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        paths = self.__get_authorized_pathes(href, action)
+        paths = self.get_authorized_pathes(href, action)
 
-        prefix = "/".join([noslash(self.get_configuration().endpoint), noslash(self.get_configuration().bucket)])
+        prefix = join_pathes(self.get_configuration().endpoint, self.get_configuration().bucket)
         h = endslash(noslash(href))
-        return any(list(map(lambda p: h.startswith(endslash("/".join([prefix, noslash(p)]))), paths)))
-
+        return any(list(map(lambda p: h.startswith(endslash(join_pathes(prefix, p))), paths)))
 
     def to_string(self) -> str:
         return "object storage on bucket {} from {}".format(self.get_configuration().bucket, self.get_configuration().endpoint)
@@ -30,7 +28,7 @@ class S3Storage(AbstractStorage):
         assert isinstance(self.storage_configuration, S3StorageConfiguration)
         return self.storage_configuration
 
-    def get_storage_parameters(self):
+    def get_storage_parameters(self) -> dict:
         import boto3
         conf = self.get_configuration()
         if conf.is_anon_client:
@@ -90,9 +88,9 @@ class S3Storage(AbstractStorage):
 
     def get_full_href(self, path: str):
         if self.get_configuration().endpoint:
-            return join_pathes(self.get_configuration().endpoint + "/" + self.get_configuration().bucket + "/" + path.removeprefix("/"))
+            return join_pathes(self.get_configuration().endpoint, self.get_configuration().bucket, path)
         else:
-            return "s3://" + self.get_configuration().bucket + "/" + path.removeprefix("/")
+            return "s3://" + join_pathes(self.get_configuration().bucket, path)
 
     def __get_href_key(self, href: str):
         return urlparse(href).path.removeprefix(f"/{self.get_configuration().bucket}").removeprefix("/").removesuffix("/") 
@@ -260,7 +258,7 @@ class S3Storage(AbstractStorage):
 
     def get_matching_s3_objects(self, path: str, suffix: str = "", s3_client=None):
 
-        prefix = self.__noslash(urlparse(path).path.removeprefix("/" + self.get_configuration().bucket))
+        prefix = noslash(urlparse(path).path.removeprefix("/" + self.get_configuration().bucket))
         LOGGER.debug("Search for objects in bucket %s with prefix %s and suffix %s", self.get_configuration().bucket, prefix, suffix)
         import botocore.client
         client: botocore.client.BaseClient = self.get_storage_parameters()["client"]

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -1,7 +1,7 @@
 import os
 from urllib.parse import urlparse, urlunparse
 
-from aias_common.access.configuration import S3StorageConfiguration
+from aias_common.access.configuration import AccessType, S3StorageConfiguration
 from aias_common.access.file import File
 from aias_common.access.logger import Logger
 from aias_common.access.storages.abstract import AbstractStorage
@@ -11,6 +11,25 @@ LOGGER = Logger.logger
 
 
 class S3Storage(AbstractStorage):
+
+    def is_path_authorized(self, href: str, action: AccessType) -> bool:
+        if action == AccessType.WRITE:
+            paths = self.get_configuration().writable_paths
+        else:
+            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+
+        prefix = "/".join([self.__noslash(self.get_configuration().endpoint), self.__noslash(self.get_configuration().bucket)])
+        h = self.__endslash(href)
+        return any(list(map(lambda p: h.startswith(self.__endslash("/".join([prefix, self.__noslash(p)]))), paths)))
+
+    def __noslash(self, txt: str) -> str:
+        return txt.removeprefix("/").removesuffix("/")
+
+    def __endslash(self, txt: str) -> str:
+        return txt.removesuffix("/") + "/"
+
+    def to_string(self) -> str:
+        return "object storage on bucket {} from {}".format(self.get_configuration().bucket, self.get_configuration().endpoint)
 
     def get_configuration(self) -> S3StorageConfiguration:
         assert isinstance(self.storage_configuration, S3StorageConfiguration)
@@ -53,7 +72,7 @@ class S3Storage(AbstractStorage):
     def exists(self, href: str):
         return self.is_dir(href) or self.is_file(href)
 
-    def get_rasterio_session(self):
+    def get_rasterio_session(self, href):
         import rasterio.session
 
         params = {}
@@ -79,7 +98,6 @@ class S3Storage(AbstractStorage):
 
     def pull(self, href: str, dst: str):
         import botocore.client
-        super().pull(href, dst)
 
         client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
 
@@ -90,7 +108,6 @@ class S3Storage(AbstractStorage):
 
     def push(self, href: str, dst: str, content_type: str | None = None):
         import botocore.client
-        super().push(href, dst)
         client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
         extraArgs = {}
         if content_type:
@@ -182,7 +199,7 @@ class S3Storage(AbstractStorage):
                 is_dir=True), objects["CommonPrefixes"]))
         return files + dirs
 
-    def get_last_modification_time(self, href: str):
+    def get_last_modification_time(self, href: str) -> float | None:
         import botocore.exceptions
         try:
             response = self.__head_object(href)
@@ -194,7 +211,7 @@ class S3Storage(AbstractStorage):
         except botocore.exceptions.ParamValidationError:  # key LastModified does not exists for root
             return None
 
-    def get_creation_time(self, href: str):
+    def get_creation_time(self, href: str) -> float | None:
         # There is no difference in s3 between last update and creation date
         return self.get_last_modification_time(href)
 

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -170,7 +170,7 @@ class S3Storage(AbstractStorage):
     def get_file_size(self, href: str):
         response = self.__head_object(href)
         if response:
-            return self.__head_object(href)['ContentLength']
+            return response['ContentLength']
         else:
             return None
 
@@ -222,7 +222,7 @@ class S3Storage(AbstractStorage):
     def clean(self, href: str):
         import botocore.client
         client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
-        client.delete_object(Bucket=self.get_configuration().bucket, Key=href)
+        client.delete_object(Bucket=self.get_configuration().bucket, Key=self.__get_href_key(href))
 
     def get_gdal_stream_options(self):
         config = self.get_configuration()

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -8,26 +8,20 @@ from aias_common.access.logger import Logger
 from aias_common.access.storages.abstract import AbstractStorage
 from fastapi_utilities import ttl_lru_cache
 
+from aias_common.access.storages.path_helper import endslash, noslash
+
 LOGGER = Logger.logger
 
 
 class S3Storage(AbstractStorage):
 
     def is_path_authorized(self, href: str, action: AccessType) -> bool:
-        if action == AccessType.WRITE:
-            paths = self.get_configuration().writable_paths
-        else:
-            paths = list([*self.get_configuration().readable_paths, *self.get_configuration().writable_paths])
+        paths = self.__get_authorized_pathes(href, action)
 
-        prefix = "/".join([self.__noslash(self.get_configuration().endpoint), self.__noslash(self.get_configuration().bucket)])
-        h = self.__endslash(self.__noslash(href))
-        return any(list(map(lambda p: h.startswith(self.__endslash("/".join([prefix, self.__noslash(p)]))), paths)))
+        prefix = "/".join([noslash(self.get_configuration().endpoint), noslash(self.get_configuration().bucket)])
+        h = endslash(noslash(href))
+        return any(list(map(lambda p: h.startswith(endslash("/".join([prefix, noslash(p)]))), paths)))
 
-    def __noslash(self, txt: str) -> str:
-        return txt.removeprefix("/").removesuffix("/")
-
-    def __endslash(self, txt: str) -> str:
-        return txt.removesuffix("/") + "/"
 
     def to_string(self) -> str:
         return "object storage on bucket {} from {}".format(self.get_configuration().bucket, self.get_configuration().endpoint)
@@ -96,7 +90,7 @@ class S3Storage(AbstractStorage):
 
     def get_full_href(self, path: str):
         if self.get_configuration().endpoint:
-            return self.get_configuration().endpoint + "/" + self.get_configuration().bucket + "/" + path.removeprefix("/")
+            return join_pathes(self.get_configuration().endpoint + "/" + self.get_configuration().bucket + "/" + path.removeprefix("/"))
         else:
             return "s3://" + self.get_configuration().bucket + "/" + path.removeprefix("/")
 
@@ -264,7 +258,7 @@ class S3Storage(AbstractStorage):
 
         return href
 
-    def get_matching_s3_objects(self, path, suffix="", s3_client=None):
+    def get_matching_s3_objects(self, path: str, suffix: str = "", s3_client=None):
 
         prefix = self.__noslash(urlparse(path).path.removeprefix("/" + self.get_configuration().bucket))
         LOGGER.debug("Search for objects in bucket %s with prefix %s and suffix %s", self.get_configuration().bucket, prefix, suffix)

--- a/python/aias_common/access/storages/utils.py
+++ b/python/aias_common/access/storages/utils.py
@@ -20,3 +20,22 @@ def requests_head(href: str, headers: dict) -> requests.Response:
 def requests_exists(href: str, headers: dict) -> bool:
     r = requests_head(href, headers)
     return r.status_code >= 200 and r.status_code < 300
+
+
+def remote_path_starts_with(path: str, prefix: str) -> bool:
+    """
+    Check whether a remote path (e.g., a cloud storage URI) is under a given prefix.
+
+    This function normalizes both `path` and `prefix` by stripping trailing slashes,
+    then checks whether `path` is exactly equal to `prefix` or is a subpath of it.
+
+    Parameters:
+        path (str): The full remote path to check, e.g., "gs://bucket/folder/file.txt".
+        prefix (str): The expected prefix path, e.g., "gs://bucket/folder".
+
+    Returns:
+        bool: True if `path` is equal to or is a subpath of `prefix`, False otherwise.
+    """
+    path = path.rstrip("/")
+    prefix = prefix.rstrip("/")
+    return path == prefix or path.startswith(prefix + "/")

--- a/python/aias_common/access/storages/utils.py
+++ b/python/aias_common/access/storages/utils.py
@@ -19,6 +19,7 @@ def requests_head(href: str, headers: dict) -> requests.Response:
 
 def requests_exists(href: str, headers: dict) -> bool:
     r = requests_head(href, headers)
+    print("request on  {}".format(href))
     return r.status_code >= 200 and r.status_code < 300
 
 

--- a/python/aias_common/access/storages/utils.py
+++ b/python/aias_common/access/storages/utils.py
@@ -19,7 +19,6 @@ def requests_head(href: str, headers: dict) -> requests.Response:
 
 def requests_exists(href: str, headers: dict) -> bool:
     r = requests_head(href, headers)
-    print("request on  {}".format(href))
     return r.status_code >= 200 and r.status_code < 300
 
 

--- a/python/aias_common/access/storages/utils.py
+++ b/python/aias_common/access/storages/utils.py
@@ -20,22 +20,3 @@ def requests_head(href: str, headers: dict) -> requests.Response:
 def requests_exists(href: str, headers: dict) -> bool:
     r = requests_head(href, headers)
     return r.status_code >= 200 and r.status_code < 300
-
-
-def remote_path_starts_with(path: str, prefix: str) -> bool:
-    """
-    Check whether a remote path (e.g., a cloud storage URI) is under a given prefix.
-
-    This function normalizes both `path` and `prefix` by stripping trailing slashes,
-    then checks whether `path` is exactly equal to `prefix` or is a subpath of it.
-
-    Parameters:
-        path (str): The full remote path to check, e.g., "gs://bucket/folder/file.txt".
-        prefix (str): The expected prefix path, e.g., "gs://bucket/folder".
-
-    Returns:
-        bool: True if `path` is equal to or is a subpath of `prefix`, False otherwise.
-    """
-    path = path.rstrip("/")
-    prefix = prefix.rstrip("/")
-    return path == prefix or path.startswith(prefix + "/")

--- a/python/airs/core/product_registration.py
+++ b/python/airs/core/product_registration.py
@@ -138,13 +138,16 @@ def __s3storage() -> S3Storage:
     return S3Storage(S3StorageConfiguration(
         bucket=Configuration.settings.s3.bucket, 
         endpoint=Configuration.settings.s3.endpoint_url,
+        readable_paths=Configuration.settings.s3.readable_paths,
+        writable_paths=Configuration.settings.s3.writable_paths,
         api_key=S3ApiKey(access_key=Configuration.settings.s3.access_key_id, secret_key=Configuration.settings.s3.secret_access_key)))
 
 
 def __upload_file(key, file_obj, content_type) -> str:
     try:
         LOGGER.info("uploading {} ...".format(key))
-        __s3storage().push_file_obj(file_obj=file_obj, dst=key, content_type=content_type)
+        dst = __s3storage().get_full_href(key)
+        __s3storage().push_file_obj(file_obj, dst, content_type)
         LOGGER.info("{} uploaded.".format(key))
         return key
     except Exception as e:
@@ -157,7 +160,7 @@ def __upload_file(key, file_obj, content_type) -> str:
 def __delete_file(key):
     try:
         LOGGER.info("deleting {} ...".format(key))
-        __s3storage().clean(key)
+        __s3storage().clean(__s3storage().get_full_href(key))
         LOGGER.info(__DELETED_MSG__.format(key))
     except Exception as e:
         msg = "Failed to delete {} ".format(key)
@@ -173,7 +176,8 @@ def __upload_item(key, item: Item) -> str:
             fn = os.path.join(td, 'item')
             with open(fn, 'w') as f:
                 f.write(to_json(item))
-            __s3storage().push(fn, key, MimeType.JSON.value)
+            dst = __s3storage().get_full_href(key)
+            __s3storage().push(fn, dst, MimeType.JSON.value)
         LOGGER.info("{} uploaded.".format(key))
         return key
     except Exception as e:
@@ -196,7 +200,7 @@ def asset_exists(collection: str, item_id: str, asset_name: str) -> bool:
         bool: True if found on the S3, False otherwise
     """
     key = get_asset_relative_path(collection, item_id, asset_name)
-    return __s3storage().exists(key)
+    return __s3storage().exists(__s3storage().get_full_href(key))
 
 
 def delete_item(collection: str, item_id: str):
@@ -207,7 +211,7 @@ def delete_item(collection: str, item_id: str):
     r = __getES().delete(index=__get_es_index_name(collection), id=item_id)
     # the item is dereferenced from ES and the STAC json file is deleted, not the rest.
     LOGGER.info("deleting {} ...".format(get_item_relative_path(collection, item_id)))
-    __s3storage().clean(get_item_relative_path(collection, item_id))
+    __s3storage().clean(__s3storage().get_full_href(get_item_relative_path(collection, item_id)))
     LOGGER.info(__DELETED_MSG__.format(get_item_relative_path(collection, item_id)))
 
 
@@ -292,13 +296,13 @@ def reindex(collection: str):
         collection (str): name of the collection to reindex
     """
     keys = __s3storage().get_matching_s3_objects(
-        collection, ITEM_ARLAS_SUFFIX
+        __s3storage().get_full_href(collection), ITEM_ARLAS_SUFFIX
     )
     LOGGER.info("Start reindexing collection {}".format(collection))
     for key in keys:
         tmp_file = "tmp" + ITEM_ARLAS_SUFFIX
         LOGGER.info("Reindexing item from {}".format(key))
-        __s3storage().pull(key, tmp_file)
+        __s3storage().pull(__s3storage().get_full_href(key), tmp_file)
         with open(tmp_file, "r") as f:
             item = item_from_json_file(f)
             LOGGER.debug(item)

--- a/python/airs/core/settings.py
+++ b/python/airs/core/settings.py
@@ -14,6 +14,8 @@ class S3(BaseModel):
     asset_http_endpoint_url: str | None = Field(None, title="Asset URL endpoint", description="Asset URL endpoint with placeholders for bucket and collection names (e.g. http://minio:9000/{}/{})")
     endpoint_url: str | None = Field(None, title="URL endpoint", description="URL endpoint (e.g. http://minio:9000)")
     bucket: str | None = Field(None, title="Bucket name", description="Bucket name")
+    writable_paths: list[str] = Field(default=[], title="Writable Paths", description="List of paths where files can be written")
+    readable_paths: list[str] = Field(default=[], title="Readable Paths", description="List of paths from which files can be read")
 
 
 class Index(BaseModel, extra="allow"):

--- a/python/extensions/aproc/proc/drivers/driver_manager.py
+++ b/python/extensions/aproc/proc/drivers/driver_manager.py
@@ -27,7 +27,7 @@ class DriverManager():
                 raise DriverException("Driver {} not found".format(driver_configuration.class_name))
 
             try:
-                AccessManager.check_local_path_writable(driver_class.assets_dir)
+                AccessManager.check_path_writable(driver_class.assets_dir)
                 if driver_class.assets_dir == "/":
                     raise ValueError("Driver {} assets_dir is not authorized for writing".format(driver_configuration.class_name))
             except ValueError as e:

--- a/python/extensions/aproc/proc/processes/arlas_services_helper.py
+++ b/python/extensions/aproc/proc/processes/arlas_services_helper.py
@@ -93,7 +93,7 @@ class ARLASServicesHelper(ABC):
 
         for key in upload_file_names:
             local_path = os.path.join(directory, key.strip("/"))
-            destpath = os.path.join(s3_dir, key.strip("/"))
+            destpath = storage.get_full_href("/".join([s3_dir, key.strip("/")]))
             mime_type, __ = mimetypes.guess_type(local_path, strict=False)
             Process.LOGGER.info("Copy {} ({}) to {}".format(local_path, mime_type, destpath))
             storage.push(local_path, destpath, mime_type)

--- a/test/access_manager_gdal_tests.py
+++ b/test/access_manager_gdal_tests.py
@@ -28,3 +28,19 @@ def test_gdal_fail(fixture_am, href: str):
         manager.AccessManager.get_gdal_proj(href)
     with pytest.raises(PermissionError):
         manager.AccessManager.get_gdal_info(href, gdal_options=gdal.InfoOptions(format='json'))
+
+
+###########################
+# raster io
+###########################
+
+@pytest.mark.parametrize("href", FILES)
+def test_get_rasterio_session(fixture_am, href: str):
+    manager.AccessManager.get_rasterio_session(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_get_rasterio_session_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_rasterio_session(href)
+

--- a/test/access_manager_gdal_tests.py
+++ b/test/access_manager_gdal_tests.py
@@ -1,0 +1,30 @@
+import pytest
+import aias_common.access.manager as manager
+
+from test.access_manager_tests import CAN_NOT_READ, GDAL_FILES, fixture_am
+
+
+###########################
+# GDAL
+###########################
+
+@pytest.mark.parametrize("href", GDAL_FILES)
+def test_gdal(fixture_am, href: str):
+    from osgeo import gdal
+    manager.AccessManager.get_gdal_src(href)
+    manager.AccessManager.get_gdal_md(href)
+    manager.AccessManager.get_gdal_proj(href)
+    manager.AccessManager.get_gdal_info(href, gdal_options=gdal.InfoOptions(format='json'))
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_gdal_fail(fixture_am, href: str):
+    from osgeo import gdal
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_gdal_src(href)
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_gdal_md(href)
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_gdal_proj(href)
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_gdal_info(href, gdal_options=gdal.InfoOptions(format='json'))

--- a/test/access_manager_gdal_tests.py
+++ b/test/access_manager_gdal_tests.py
@@ -34,7 +34,7 @@ def test_gdal_fail(fixture_am, href: str):
 # raster io
 ###########################
 
-@pytest.mark.parametrize("href", FILES)
+@pytest.mark.parametrize("href", GDAL_FILES)
 def test_get_rasterio_session(fixture_am, href: str):
     manager.AccessManager.get_rasterio_session(href)
 

--- a/test/access_manager_tests.py
+++ b/test/access_manager_tests.py
@@ -376,21 +376,6 @@ def test_get_size_fail(fixture_am, href: str):
 
 
 ###########################
-# raster io
-###########################
-
-@pytest.mark.parametrize("href", FILES)
-def test_get_rasterio_session(fixture_am, href: str):
-    manager.AccessManager.get_rasterio_session(href)
-
-
-@pytest.mark.parametrize("href", CAN_NOT_READ)
-def test_get_rasterio_session_fail(fixture_am, href: str):
-    with pytest.raises(PermissionError):
-        manager.AccessManager.get_rasterio_session(href)
-
-
-###########################
 # LIST DIR
 ###########################
 

--- a/test/access_manager_tests.py
+++ b/test/access_manager_tests.py
@@ -1,10 +1,9 @@
 import os
 import pytest
-from aias_common.access.configuration import AccessManagerSettings, AccessType, HttpsStorageConfiguration
+from aias_common.access.configuration import AccessManagerSettings, HttpsStorageConfiguration
 import aias_common.access.storages.s3 as s3
 import aias_common.access.manager as manager
 import aias_common.access.storages.file as fs
-import aias_common.access.storages.http as http
 import aias_common.access.storages.gs as gs
 from pathlib import Path
 import os.path as p
@@ -36,7 +35,7 @@ FS_RO_FILE = "/tmp/readonly/file"
 FS_RW_FILE = "/tmp/readwrite/file"
 
 GDAL_FILES = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/jpeg2000.jpg2", "gs:///gisaia-public/test-aias/jpeg2000.jpg2"
+    "https://storage.googleapis.com/gisaia-public/test-aias/jpeg2000.jpg2", "gs://gisaia-public/test-aias/jpeg2000.jpg2"
 ]
 
 
@@ -63,24 +62,7 @@ CAN_READ = [
     FS_RW_FILE,
 ]
 
-GET_SIZE = [
-    GS_RO_FILE,
-    GS_RO_DIR_SLASH,
-    GS_RO_DIR_NO_SLASH,
-
-    HTTPS_RO_FILE,
-
-    S3_RO_DIR_SLASH,
-    S3_RO_DIR_NO_SLASH,
-    S3_RO_FILE,
-    S3_RO_DIR,
-    S3_RW_DIR,
-
-    FS_RO_DIR_NO_SLASH,
-    FS_RW_DIR_SLASH,
-    FS_RO_FILE,
-    FS_RW_FILE,
-]
+GET_SIZE = CAN_READ
 
 FILES = [
     GS_RO_FILE,

--- a/test/access_manager_tests.py
+++ b/test/access_manager_tests.py
@@ -7,101 +7,189 @@ import aias_common.access.storages.file as fs
 import aias_common.access.storages.http as http
 import aias_common.access.storages.gs as gs
 from pathlib import Path
+import os.path as p
 
+MINIO_HOST = "minio"
+
+
+###########################
+# FILES AND DIR VARIABLES
+###########################
+
+S3_RO_DIR_SLASH = "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/"
+S3_RO_DIR_NO_SLASH = "https://storage.googleapis.com/gisaia-public/test-aias/ast"
+S3_RO_FILE = "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw"
+S3_RO_DIR = "http://" + MINIO_HOST + ":9000/downloads/readonly/"
+S3_RW_DIR = "http://" + MINIO_HOST + ":9000/downloads/readwrite/"
+S3_RW_FILE = "http://" + MINIO_HOST + ":9000/downloads/readwrite/a_file"
+
+GS_RO_DIR_NO_SLASH = "gs://gisaia-public/test-aias/ast"
+GS_RO_DIR_SLASH = "gs://gisaia-public/test-aias/DIMAP/"
+GS_RO_FILE = "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw"
+
+HTTPS_RO_FILE = "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md"
+
+FS_RO_DIR_NO_SLASH = "/tmp/readonly"
+FS_RW_DIR_SLASH = "/tmp/readwrite/"
+
+FS_RO_FILE = "/tmp/readonly/file"
+FS_RW_FILE = "/tmp/readwrite/file"
+
+GDAL_FILES = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/jpeg2000.jpg2", "gs:///gisaia-public/test-aias/jpeg2000.jpg2"
+]
+
+
+###########################
+# PARAMETER MATRICES
+###########################
 
 CAN_READ = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
-    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/",
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
-    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
-    "gs://gisaia-public/test-aias/ast",
-    "gs://gisaia-public/test-aias/DIMAP/",
-    "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
-    "/tmp",
-    "/tmp/",
+    GS_RO_FILE,
+    GS_RO_DIR_SLASH,
+    GS_RO_DIR_NO_SLASH,
+
+    HTTPS_RO_FILE,
+
+    S3_RO_DIR_SLASH,
+    S3_RO_DIR_NO_SLASH,
+    S3_RO_FILE,
+    S3_RO_DIR,
+    S3_RW_DIR,
+
+    FS_RO_DIR_NO_SLASH,
+    FS_RW_DIR_SLASH,
+    FS_RO_FILE,
+    FS_RW_FILE,
 ]
 
 GET_SIZE = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
-    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
-    "gs://gisaia-public/test-aias/ast",
-    "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw"
-]
+    GS_RO_FILE,
+    GS_RO_DIR_SLASH,
+    GS_RO_DIR_NO_SLASH,
 
+    HTTPS_RO_FILE,
+
+    S3_RO_DIR_SLASH,
+    S3_RO_DIR_NO_SLASH,
+    S3_RO_FILE,
+    S3_RO_DIR,
+    S3_RW_DIR,
+
+    FS_RO_DIR_NO_SLASH,
+    FS_RW_DIR_SLASH,
+    FS_RO_FILE,
+    FS_RW_FILE,
+]
 
 FILES = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
-    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
-    "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
-    "/tmp/tobepushed"
+    GS_RO_FILE,
+    S3_RO_FILE,
+    HTTPS_RO_FILE,
+    FS_RO_FILE,
+    FS_RW_FILE,
 ]
 
+
 DIRS = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
-    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/",
-    "gs://gisaia-public/test-aias/ast",
-    "gs://gisaia-public/test-aias/DIMAP/",
-    "/tmp",
-    "/tmp/",
+    GS_RO_DIR_SLASH,
+    GS_RO_DIR_NO_SLASH,
+
+    S3_RO_DIR_SLASH,
+    S3_RO_DIR_NO_SLASH,
+    S3_RO_DIR,
+    S3_RW_DIR,
+
+    FS_RO_DIR_NO_SLASH,
+    FS_RW_DIR_SLASH,
 ]
 
 MKDIRS = [
-    "/tmp/dir_for_tests",
+    FS_RW_DIR_SLASH + "dir_for_mkdir_test",
 ]
 
 CAN_NOT_READ = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/astsomething",
-    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAPsomething/",
-    "https://raw.githubusercontent.com/something",
-    "gs://gisaia-public/test-aias/astsomething",
-    "gs://gisaia-public/test-aias/DIMAPsomething/",
-    "/tmpsomething",
-    "/tmpsomething/",
-    "https://storage.googleapis.com/gisaia-public/test-aias/",
-    "https://storage.googleapis.com/gisaia-public/",
-    "https://storage.googleapis.com/",
-    "gs://gisaia-public/test-aias/astsomething",
-    "gs://gisaia-public/test-aias/DIMAPsomething/",
-    "gs://gisaia-public/test-aias/",
-    "gs://gisaia-public/",
-    "/tmpsomething",
-    "/tmpsomething/",
+    GS_RO_DIR_NO_SLASH + "something",
+    GS_RO_DIR_NO_SLASH + "andsomethingelse/",
+    p.dirname(GS_RO_DIR_NO_SLASH),
+    p.dirname(p.dirname(GS_RO_DIR_NO_SLASH)),
+
+    HTTPS_RO_FILE.replace("ARLAS-Exploration-stack", "ARLAS-Exploration-stack-something"),
+
+    S3_RO_DIR_SLASH.replace("DIMAP", "DIMAP-something"),
+    S3_RO_DIR_NO_SLASH + "something",
+    p.dirname(S3_RO_DIR_NO_SLASH),
+    p.dirname(p.dirname(S3_RO_DIR_NO_SLASH)),
+
+    p.dirname(FS_RO_DIR_NO_SLASH),
+    FS_RO_DIR_NO_SLASH + "something",
+    FS_RO_DIR_NO_SLASH + "andsomethingelse/",
     "/",
     "",
 ]
 
 CAN_WRITE = [
-    "/tmp",
-    "/tmp/"
+    FS_RW_DIR_SLASH,
+    S3_RW_DIR,
 ]
 
 CAN_NOT_WRITE = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
-    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/",
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast/something",
-    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/something",
-    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/",
-    "gs://gisaia-public/test-aias/ast",
-    "gs://gisaia-public/test-aias/DIMAP/",
-    "gs://gisaia-public/test-aias/ast/something",
-    "gs://gisaia-public/test-aias/DIMAP/something",
+    GS_RO_DIR_SLASH,
+    GS_RO_DIR_NO_SLASH,
+    GS_RO_DIR_NO_SLASH + "something",
+    GS_RO_DIR_NO_SLASH + "andsomethingelse/",
+    p.dirname(GS_RO_DIR_NO_SLASH),
+    p.dirname(p.dirname(GS_RO_DIR_NO_SLASH)),
+
+    S3_RO_DIR_SLASH,
+    S3_RO_DIR_NO_SLASH,
+    S3_RO_DIR,
+    p.dirname(S3_RO_DIR_NO_SLASH),
+    p.dirname(p.dirname(S3_RO_DIR_NO_SLASH)),
+
+    FS_RO_DIR_NO_SLASH,
+    p.dirname(FS_RO_DIR_NO_SLASH),
+    FS_RO_DIR_NO_SLASH + "something",
+    FS_RO_DIR_NO_SLASH + "andsomethingelse/",
+]
+
+
+CAN_CLEAN = [
+    S3_RW_FILE,
+    FS_RW_FILE
+]
+
+CAN_NOT_CLEAN = [
+    GS_RO_DIR_NO_SLASH + "something",
+    GS_RO_DIR_NO_SLASH + "andsomethingelse/",
+    S3_RO_DIR_NO_SLASH,
+
+    FS_RO_DIR_NO_SLASH,
+    FS_RO_DIR_NO_SLASH + "something",
+    FS_RO_DIR_NO_SLASH + "andsomethingelse/",
 ]
 
 NOT_EXISTS = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast/something",
-    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/something/",
-    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/something/docs/docs/version.md",
-    "gs://gisaia-public/test-aias/ast/something",
-    "gs://gisaia-public/test-aias/DIMAP/something/",
-    "/tmp/something",
-    "/tmp/something/"
+    GS_RO_FILE + "something",
+    GS_RO_DIR_SLASH + "something",
+
+    HTTPS_RO_FILE + "something",
+
+    S3_RO_DIR_SLASH + "something",
+    S3_RO_FILE + "something",
+    S3_RO_DIR + "something",
+    S3_RW_DIR + "something",
+
+    FS_RO_DIR_NO_SLASH + "/something",
+    FS_RW_DIR_SLASH + "something",
+    FS_RO_FILE + "something",
+    FS_RW_FILE + "something",
 ]
 
 CAN_PULL = [
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
-    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
-    "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw"
+    GS_RO_FILE,
+    S3_RO_FILE,
+    HTTPS_RO_FILE,
 ]
 
 CAN_NOT_PULL = [
@@ -112,46 +200,56 @@ CAN_NOT_PULL = [
 
 
 CAN_PUSH_ON = [
-    "http://localhost:9000/downloads/readwrite/pushed"
+    S3_RW_DIR + "pushed"
 ]
 
 
 CAN_NOT_PUSH_ON = [
-    "http://localhost:9000/downloads/read/pushed",
-    "http://localhost:9000/downloads/pushed",
-    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
-    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/",
+    S3_RO_DIR + "pushed",
+    S3_RO_DIR_SLASH + "pushed",
+    S3_RO_DIR_NO_SLASH + "/pushed",
     "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
-    "gs://gisaia-public/test-aias/ast",
-    "gs://gisaia-public/test-aias/DIMAP/"
+    GS_RO_DIR_SLASH + "pushed",
+    GS_RO_DIR_NO_SLASH + "/pushed",
 ]
 
 
+###########################
+# FIXTURES
+###########################
+
 @pytest.fixture(scope="class")
 def fixture_am():
+    os.makedirs(FS_RO_DIR_NO_SLASH, exist_ok=True)
+    os.makedirs(FS_RW_DIR_SLASH, exist_ok=True)
+    Path(FS_RO_FILE).touch()
+    Path(FS_RW_FILE).touch()
+
+    minios3conf = s3.S3StorageConfiguration(bucket="downloads", endpoint="http://" + MINIO_HOST + ":9000", readable_paths=["readwrite", "readonly"], writable_paths=["readwrite", "readonly"])
+    minios3 = s3.S3Storage(minios3conf)
+    minios3.push(FS_RO_FILE, S3_RO_DIR + "a_file")
+    minios3.push(FS_RO_FILE, S3_RW_FILE)
+
     manager.AccessManager.init(AccessManagerSettings(
         storages=[
-            s3.S3StorageConfiguration(bucket="downloads", endpoint="http://localhost:9000", readable_paths=["readwrite", "readonly"], writable_paths=["readwrite"]),
+            s3.S3StorageConfiguration(bucket="downloads", endpoint="http://" + MINIO_HOST + ":9000", readable_paths=["readwrite", "readonly"], writable_paths=["readwrite"]),
             s3.S3StorageConfiguration(bucket="gisaia-public", endpoint="https://storage.googleapis.com", readable_paths=["/test-aias/ast", "test-aias/DIMAP"]),
-            fs.FileStorageConfiguration(readable_paths=["/tmp/"], writable_paths=["/tmp/"]),
+            fs.FileStorageConfiguration(readable_paths=["/tmp/readonly"], writable_paths=["/tmp/readwrite"]),
             HttpsStorageConfiguration(domain="raw.githubusercontent.com", readable_paths=["/gisaia/ARLAS-Exploration-stack"], writable_paths=[]),
             gs.GoogleStorageConfiguration(bucket="gisaia-public", readable_paths=["/test-aias/ast", "test-aias/DIMAP"])
         ],
-        tmp_dir="/tmp/"
+        tmp_dir="/tmp/readwrite"
     ))
 
 
 @pytest.fixture(scope="class")
 def fixture_objectstore() -> s3.S3Storage:
-    return s3.S3Storage(s3.S3StorageConfiguration(bucket="downloads", endpoint="http://localhost:9000", readable_paths=["readwrite", "readonly"], writable_paths=["readwrite"]))
+    return s3.S3Storage(s3.S3StorageConfiguration(bucket="downloads", endpoint="http://" + MINIO_HOST + ":9000", readable_paths=["readwrite", "readonly"], writable_paths=["readwrite"]))
 
 
-@pytest.fixture(scope="class")
-def fixture_tobepushed():
-    fl = os.path.join(manager.AccessManager.tmp_dir, "tobepushed")
-    Path(fl).touch()
-    return fl
-
+###########################
+# CAN READ
+###########################
 
 @pytest.mark.parametrize("href", CAN_READ)
 def test_can_read(fixture_am, href: str):
@@ -164,6 +262,10 @@ def test_can_not_read(fixture_am, href: str):
         manager.AccessManager.check_path_readable(href)
 
 
+###########################
+# CAN WRITE
+###########################
+
 @pytest.mark.parametrize("href", CAN_WRITE)
 def test_can_write(fixture_am, href: str):
     manager.AccessManager.check_path_writable(href)
@@ -175,6 +277,10 @@ def test_can_not_write(fixture_am, href: str):
         manager.AccessManager.check_path_writable(href)
 
 
+###########################
+# EXISTS
+###########################
+
 @pytest.mark.parametrize("href", CAN_READ)
 def test_exists(fixture_am, href: str):
     assert manager.AccessManager.exists(href)
@@ -184,6 +290,10 @@ def test_exists(fixture_am, href: str):
 def test_not_exists(fixture_am, href: str):
     assert not manager.AccessManager.exists(href)
 
+
+###########################
+# PULL
+###########################
 
 @pytest.mark.parametrize("href", CAN_PULL)
 def test_pull(fixture_am, href: str):
@@ -196,32 +306,40 @@ def test_not_pull(fixture_am, href: str):
         manager.AccessManager.pull(href, os.path.join(manager.AccessManager.tmp_dir, "pulled"))
 
 
+###########################
+# PUSH
+###########################
+
 @pytest.mark.parametrize("href", CAN_PUSH_ON)
-def test_push(fixture_am, fixture_tobepushed, href: str):
-    manager.AccessManager.push(fixture_tobepushed, href)
+def test_push(fixture_am, href: str):
+    manager.AccessManager.push(FS_RO_FILE, href)
 
 
 @pytest.mark.parametrize("href", CAN_NOT_WRITE)
-def test_not_push(fixture_am, fixture_tobepushed, href: str):
+def test_not_push(fixture_am, href: str):
     with pytest.raises(PermissionError):
-        manager.AccessManager.push(fixture_tobepushed, href)
+        manager.AccessManager.push(FS_RO_FILE, href)
 
 
 @pytest.mark.parametrize("href", CAN_PUSH_ON)
-def test_push_fo(fixture_am, fixture_tobepushed, fixture_objectstore: s3.S3Storage, href: str):
-    with open(fixture_tobepushed, 'rb') as fo:
+def test_push_fo(fixture_am, fixture_objectstore: s3.S3Storage, href: str):
+    with open(FS_RO_FILE, 'rb') as fo:
         fixture_objectstore.push_file_obj(fo, href)
 
 
 @pytest.mark.parametrize("href", CAN_NOT_WRITE)
-def test_not_push_fo(fixture_am, fixture_tobepushed, fixture_objectstore: s3.S3Storage, href: str):
+def test_not_push_fo(fixture_am, fixture_objectstore: s3.S3Storage, href: str):
     with pytest.raises(PermissionError):
-        with open(fixture_tobepushed, 'rb') as fo:
+        with open(FS_RO_FILE, 'rb') as fo:
             fixture_objectstore.push_file_obj(fo, href)
 
 
+###########################
+# IS FILE / DIR
+###########################
+
 @pytest.mark.parametrize("href", FILES)
-def test_is_file(fixture_am, fixture_tobepushed, href: str):
+def test_is_file(fixture_am, href: str):
     assert manager.AccessManager.is_file(href)
 
 
@@ -232,7 +350,7 @@ def test_is_file_fail(fixture_am, href: str):
 
 
 @pytest.mark.parametrize("href", DIRS)
-def test_is_dir(fixture_am, fixture_tobepushed, href: str):
+def test_is_dir(fixture_am, href: str):
     assert manager.AccessManager.is_dir(href)
 
 
@@ -242,9 +360,13 @@ def test_is_dir_fail(fixture_am, href: str):
         manager.AccessManager.is_dir(href)
 
 
+###########################
+# GET SIZE
+###########################
+
 @pytest.mark.parametrize("href", GET_SIZE)
-def test_get_size(fixture_am, fixture_tobepushed, href: str):
-    assert manager.AccessManager.get_size(href)
+def test_get_size(fixture_am, href: str):
+    manager.AccessManager.get_size(href)
 
 
 @pytest.mark.parametrize("href", CAN_NOT_READ)
@@ -253,8 +375,12 @@ def test_get_size_fail(fixture_am, href: str):
         manager.AccessManager.get_size(href)
 
 
+###########################
+# raster io
+###########################
+
 @pytest.mark.parametrize("href", FILES)
-def test_get_rasterio_session(fixture_am, fixture_tobepushed, href: str):
+def test_get_rasterio_session(fixture_am, href: str):
     manager.AccessManager.get_rasterio_session(href)
 
 
@@ -264,8 +390,12 @@ def test_get_rasterio_session_fail(fixture_am, href: str):
         manager.AccessManager.get_rasterio_session(href)
 
 
+###########################
+# LIST DIR
+###########################
+
 @pytest.mark.parametrize("href", DIRS)
-def test_listdir(fixture_am, fixture_tobepushed, href: str):
+def test_listdir(fixture_am, href: str):
     manager.AccessManager.listdir(href)
 
 
@@ -275,8 +405,12 @@ def test_listdir_fail(fixture_am, href: str):
         manager.AccessManager.listdir(href)
 
 
+###########################
+# GET DATES
+###########################
+
 @pytest.mark.parametrize("href", FILES)
-def test_get_last_modification_time(fixture_am, fixture_tobepushed, href: str):
+def test_get_last_modification_time(fixture_am, href: str):
     print(manager.AccessManager.get_last_modification_time(href))
 
 
@@ -287,7 +421,7 @@ def test_get_last_modification_time_fail(fixture_am, href: str):
 
 
 @pytest.mark.parametrize("href", FILES)
-def test_get_creation_time(fixture_am, fixture_tobepushed, href: str):
+def test_get_creation_time(fixture_am, href: str):
     print(manager.AccessManager.get_creation_time(href))
 
 
@@ -297,8 +431,12 @@ def test_get_creation_time_fail(fixture_am, href: str):
         manager.AccessManager.get_creation_time(href)
 
 
+###########################
+# MKDIR
+###########################
+
 @pytest.mark.parametrize("href", MKDIRS)
-def test_makedir(fixture_am, fixture_tobepushed, href: str):
+def test_makedir(fixture_am, href: str):
     manager.AccessManager.makedir(href)
 
 
@@ -308,8 +446,12 @@ def test_makedir_fail(fixture_am, href: str):
         manager.AccessManager.makedir(href)
 
 
+###########################
+# DIRNAME
+###########################
+
 @pytest.mark.parametrize("href", DIRS)
-def test_dirname(fixture_am, fixture_tobepushed, href: str):
+def test_dirname(fixture_am, href: str):
     manager.AccessManager.dirname(href)
 
 
@@ -319,12 +461,33 @@ def test_dirname_fail(fixture_am, href: str):
         manager.AccessManager.dirname(href)
 
 
-@pytest.mark.parametrize("href", DIRS)
-def test_clean(fixture_am, fixture_tobepushed, href: str):
-    manager.AccessManager.dirname(href)
+###########################
+# CLEAN
+###########################
+
+@pytest.mark.parametrize("href", CAN_CLEAN)
+def test_clean(fixture_am, href: str):
+    print(href)
+    manager.AccessManager.clean(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_CLEAN)
+def test_clean_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.clean(href)
+
+
+###########################
+# ZIP
+###########################
+
+@pytest.mark.parametrize("href", FILES)
+def test_zip(fixture_am, href: str):
+    manager.AccessManager.zip(href, FS_RW_DIR_SLASH + "file.zip")
 
 
 @pytest.mark.parametrize("href", CAN_NOT_READ)
-def test_dirname_fail(fixture_am, href: str):
+def test_zip_fail(fixture_am, href: str):
     with pytest.raises(PermissionError):
-        manager.AccessManager.dirname(href)
+        manager.AccessManager.zip(href, FS_RW_DIR_SLASH + "file.zip")
+

--- a/test/access_manager_tests.py
+++ b/test/access_manager_tests.py
@@ -1,0 +1,330 @@
+import os
+import pytest
+from aias_common.access.configuration import AccessManagerSettings, AccessType, HttpsStorageConfiguration
+import aias_common.access.storages.s3 as s3
+import aias_common.access.manager as manager
+import aias_common.access.storages.file as fs
+import aias_common.access.storages.http as http
+import aias_common.access.storages.gs as gs
+from pathlib import Path
+
+
+CAN_READ = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
+    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/",
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
+    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
+    "gs://gisaia-public/test-aias/ast",
+    "gs://gisaia-public/test-aias/DIMAP/",
+    "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
+    "/tmp",
+    "/tmp/",
+]
+
+GET_SIZE = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
+    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
+    "gs://gisaia-public/test-aias/ast",
+    "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw"
+]
+
+
+FILES = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
+    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
+    "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
+    "/tmp/tobepushed"
+]
+
+DIRS = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
+    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/",
+    "gs://gisaia-public/test-aias/ast",
+    "gs://gisaia-public/test-aias/DIMAP/",
+    "/tmp",
+    "/tmp/",
+]
+
+MKDIRS = [
+    "/tmp/dir_for_tests",
+]
+
+CAN_NOT_READ = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/astsomething",
+    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAPsomething/",
+    "https://raw.githubusercontent.com/something",
+    "gs://gisaia-public/test-aias/astsomething",
+    "gs://gisaia-public/test-aias/DIMAPsomething/",
+    "/tmpsomething",
+    "/tmpsomething/",
+    "https://storage.googleapis.com/gisaia-public/test-aias/",
+    "https://storage.googleapis.com/gisaia-public/",
+    "https://storage.googleapis.com/",
+    "gs://gisaia-public/test-aias/astsomething",
+    "gs://gisaia-public/test-aias/DIMAPsomething/",
+    "gs://gisaia-public/test-aias/",
+    "gs://gisaia-public/",
+    "/tmpsomething",
+    "/tmpsomething/",
+    "/",
+    "",
+]
+
+CAN_WRITE = [
+    "/tmp",
+    "/tmp/"
+]
+
+CAN_NOT_WRITE = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
+    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/",
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast/something",
+    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/something",
+    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/",
+    "gs://gisaia-public/test-aias/ast",
+    "gs://gisaia-public/test-aias/DIMAP/",
+    "gs://gisaia-public/test-aias/ast/something",
+    "gs://gisaia-public/test-aias/DIMAP/something",
+]
+
+NOT_EXISTS = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast/something",
+    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/something/",
+    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/something/docs/docs/version.md",
+    "gs://gisaia-public/test-aias/ast/something",
+    "gs://gisaia-public/test-aias/DIMAP/something/",
+    "/tmp/something",
+    "/tmp/something/"
+]
+
+CAN_PULL = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw",
+    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
+    "gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw"
+]
+
+CAN_NOT_PULL = [
+    "https://storage.googleapis.com/gisaia-public/test-aias/cog.tiff",
+    "gs://gisaia-public/test-aias/cog.tiff",
+    "https://raw.githubusercontent.com/gisaia/something/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md"
+]
+
+
+CAN_PUSH_ON = [
+    "http://localhost:9000/downloads/readwrite/pushed"
+]
+
+
+CAN_NOT_PUSH_ON = [
+    "http://localhost:9000/downloads/read/pushed",
+    "http://localhost:9000/downloads/pushed",
+    "https://storage.googleapis.com/gisaia-public/test-aias/ast",
+    "https://storage.googleapis.com/gisaia-public/test-aias/DIMAP/",
+    "https://raw.githubusercontent.com/gisaia/ARLAS-Exploration-stack/adbfe2df1699df1fecc161fdb4464fcd07ad6235/docs/docs/version.md",
+    "gs://gisaia-public/test-aias/ast",
+    "gs://gisaia-public/test-aias/DIMAP/"
+]
+
+
+@pytest.fixture(scope="class")
+def fixture_am():
+    manager.AccessManager.init(AccessManagerSettings(
+        storages=[
+            s3.S3StorageConfiguration(bucket="downloads", endpoint="http://localhost:9000", readable_paths=["readwrite", "readonly"], writable_paths=["readwrite"]),
+            s3.S3StorageConfiguration(bucket="gisaia-public", endpoint="https://storage.googleapis.com", readable_paths=["/test-aias/ast", "test-aias/DIMAP"]),
+            fs.FileStorageConfiguration(readable_paths=["/tmp/"], writable_paths=["/tmp/"]),
+            HttpsStorageConfiguration(domain="raw.githubusercontent.com", readable_paths=["/gisaia/ARLAS-Exploration-stack"], writable_paths=[]),
+            gs.GoogleStorageConfiguration(bucket="gisaia-public", readable_paths=["/test-aias/ast", "test-aias/DIMAP"])
+        ],
+        tmp_dir="/tmp/"
+    ))
+
+
+@pytest.fixture(scope="class")
+def fixture_objectstore() -> s3.S3Storage:
+    return s3.S3Storage(s3.S3StorageConfiguration(bucket="downloads", endpoint="http://localhost:9000", readable_paths=["readwrite", "readonly"], writable_paths=["readwrite"]))
+
+
+@pytest.fixture(scope="class")
+def fixture_tobepushed():
+    fl = os.path.join(manager.AccessManager.tmp_dir, "tobepushed")
+    Path(fl).touch()
+    return fl
+
+
+@pytest.mark.parametrize("href", CAN_READ)
+def test_can_read(fixture_am, href: str):
+    manager.AccessManager.check_path_readable(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_can_not_read(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.check_path_readable(href)
+
+
+@pytest.mark.parametrize("href", CAN_WRITE)
+def test_can_write(fixture_am, href: str):
+    manager.AccessManager.check_path_writable(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_WRITE)
+def test_can_not_write(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.check_path_writable(href)
+
+
+@pytest.mark.parametrize("href", CAN_READ)
+def test_exists(fixture_am, href: str):
+    assert manager.AccessManager.exists(href)
+
+
+@pytest.mark.parametrize("href", NOT_EXISTS)
+def test_not_exists(fixture_am, href: str):
+    assert not manager.AccessManager.exists(href)
+
+
+@pytest.mark.parametrize("href", CAN_PULL)
+def test_pull(fixture_am, href: str):
+    manager.AccessManager.pull(href, os.path.join(manager.AccessManager.tmp_dir, "pulled"))
+
+
+@pytest.mark.parametrize("href", CAN_NOT_PULL)
+def test_not_pull(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.pull(href, os.path.join(manager.AccessManager.tmp_dir, "pulled"))
+
+
+@pytest.mark.parametrize("href", CAN_PUSH_ON)
+def test_push(fixture_am, fixture_tobepushed, href: str):
+    manager.AccessManager.push(fixture_tobepushed, href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_WRITE)
+def test_not_push(fixture_am, fixture_tobepushed, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.push(fixture_tobepushed, href)
+
+
+@pytest.mark.parametrize("href", CAN_PUSH_ON)
+def test_push_fo(fixture_am, fixture_tobepushed, fixture_objectstore: s3.S3Storage, href: str):
+    with open(fixture_tobepushed, 'rb') as fo:
+        fixture_objectstore.push_file_obj(fo, href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_WRITE)
+def test_not_push_fo(fixture_am, fixture_tobepushed, fixture_objectstore: s3.S3Storage, href: str):
+    with pytest.raises(PermissionError):
+        with open(fixture_tobepushed, 'rb') as fo:
+            fixture_objectstore.push_file_obj(fo, href)
+
+
+@pytest.mark.parametrize("href", FILES)
+def test_is_file(fixture_am, fixture_tobepushed, href: str):
+    assert manager.AccessManager.is_file(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_is_file_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.is_file(href)
+
+
+@pytest.mark.parametrize("href", DIRS)
+def test_is_dir(fixture_am, fixture_tobepushed, href: str):
+    assert manager.AccessManager.is_dir(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_is_dir_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.is_dir(href)
+
+
+@pytest.mark.parametrize("href", GET_SIZE)
+def test_get_size(fixture_am, fixture_tobepushed, href: str):
+    assert manager.AccessManager.get_size(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_get_size_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_size(href)
+
+
+@pytest.mark.parametrize("href", FILES)
+def test_get_rasterio_session(fixture_am, fixture_tobepushed, href: str):
+    manager.AccessManager.get_rasterio_session(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_get_rasterio_session_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_rasterio_session(href)
+
+
+@pytest.mark.parametrize("href", DIRS)
+def test_listdir(fixture_am, fixture_tobepushed, href: str):
+    manager.AccessManager.listdir(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_listdir_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.listdir(href)
+
+
+@pytest.mark.parametrize("href", FILES)
+def test_get_last_modification_time(fixture_am, fixture_tobepushed, href: str):
+    print(manager.AccessManager.get_last_modification_time(href))
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_get_last_modification_time_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_last_modification_time(href)
+
+
+@pytest.mark.parametrize("href", FILES)
+def test_get_creation_time(fixture_am, fixture_tobepushed, href: str):
+    print(manager.AccessManager.get_creation_time(href))
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_get_creation_time_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.get_creation_time(href)
+
+
+@pytest.mark.parametrize("href", MKDIRS)
+def test_makedir(fixture_am, fixture_tobepushed, href: str):
+    manager.AccessManager.makedir(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_WRITE)
+def test_makedir_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.makedir(href)
+
+
+@pytest.mark.parametrize("href", DIRS)
+def test_dirname(fixture_am, fixture_tobepushed, href: str):
+    manager.AccessManager.dirname(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_dirname_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.dirname(href)
+
+
+@pytest.mark.parametrize("href", DIRS)
+def test_clean(fixture_am, fixture_tobepushed, href: str):
+    manager.AccessManager.dirname(href)
+
+
+@pytest.mark.parametrize("href", CAN_NOT_READ)
+def test_dirname_fail(fixture_am, href: str):
+    with pytest.raises(PermissionError):
+        manager.AccessManager.dirname(href)

--- a/test/airs_tests.py
+++ b/test/airs_tests.py
@@ -1,4 +1,5 @@
 import os
+from time import sleep
 import unittest
 from test.utils import (AIRS_URL, ASSET, ASSET_PATH, COLLECTION, ID_MANAGED, ITEM_PATH_MANAGED,
                         index_collection_prefix, index_endpoint_url, setUpTest)

--- a/test/aproc_download_tests.py
+++ b/test/aproc_download_tests.py
@@ -50,10 +50,8 @@ class Tests(unittest.TestCase):
     @staticmethod
     def __download_found(url: str):
         if url.startswith("http"):
-            print("downloads placed on s3")
             return requests.head(url).status_code == 200
         else:
-            print("downloads placed in directory")
             return os.path.exists("./" + url)
 
     def test_download_project_native_format_native_nocrop(self):

--- a/test/fam_tests.py
+++ b/test/fam_tests.py
@@ -40,7 +40,11 @@ class Tests(unittest.TestCase):
         self.assertEqual(archive.name, "IMG_SPOT6_MS_001_A")
         self.assertEqual(archive.path, os.path.join(root.path, "DIMAP/PROD_SPOT6_001/VOL_SPOT6_001_A/IMG_SPOT6_MS_001_A/"))
         self.assertTrue(archive.is_dir)
-        self.assertIn(archive.id, ["148ddaaa431bdd2ff06b823df1e3725d462f668bd95188603bfff443ff055c71", "7fb3088260c163c8bdf37f9b56b35b0232ab8adbb556f9fbfd8d547d26bc20d1", "a75c9fc5a9fee985be7bd967ef713a20df65e7163f660bf6607436845fb48f4b"])
+        self.assertIn(archive.id, [
+            "148ddaaa431bdd2ff06b823df1e3725d462f668bd95188603bfff443ff055c71",  # 
+            "a75c9fc5a9fee985be7bd967ef713a20df65e7163f660bf6607436845fb48f4b",  # 
+            "9c74339d7d73e441e61d1b61b660d92713a163f3c212bf7dca261e4bc1e03601"   # GS
+            ])
         self.assertEqual(archive.driver_name, "dimap")
 
 if __name__ == '__main__':

--- a/test/fam_tests.py
+++ b/test/fam_tests.py
@@ -40,11 +40,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(archive.name, "IMG_SPOT6_MS_001_A")
         self.assertEqual(archive.path, os.path.join(root.path, "DIMAP/PROD_SPOT6_001/VOL_SPOT6_001_A/IMG_SPOT6_MS_001_A/"))
         self.assertTrue(archive.is_dir)
-        self.assertIn(archive.id, [
-            "148ddaaa431bdd2ff06b823df1e3725d462f668bd95188603bfff443ff055c71",  # 
-            "a75c9fc5a9fee985be7bd967ef713a20df65e7163f660bf6607436845fb48f4b",  # 
-            "9c74339d7d73e441e61d1b61b660d92713a163f3c212bf7dca261e4bc1e03601"   # GS
-            ])
+        self.assertIn(archive.id, ["148ddaaa431bdd2ff06b823df1e3725d462f668bd95188603bfff443ff055c71", "a75c9fc5a9fee985be7bd967ef713a20df65e7163f660bf6607436845fb48f4b", "9c74339d7d73e441e61d1b61b660d92713a163f3c212bf7dca261e4bc1e03601"])
         self.assertEqual(archive.driver_name, "dimap")
 
 if __name__ == '__main__':

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -16,3 +16,4 @@ jsonref==1.1.0
 pillow==10.3.0
 typer==0.9.0
 fastapi-utilities==0.3.1
+pytest==8.4.2

--- a/test/tests_am.sh
+++ b/test/tests_am.sh
@@ -9,4 +9,5 @@ docker build -f docker/Dockerfile-tests . -t pythontests
 docker ps
 
 echo "run test/access_manager_tests"
-docker run --rm -v `pwd`:/app/  --network compose_aias pythontests pytest -s test/access_manager_tests.py
+export PYTHONPATH=python
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests pytest -s "test/access_manager_tests.py::test_get_rasterio_session[gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw]"

--- a/test/tests_am.sh
+++ b/test/tests_am.sh
@@ -10,4 +10,4 @@ docker ps
 
 echo "run test/access_manager_tests"
 export PYTHONPATH=python
-docker run --rm -v `pwd`:/app/  --network compose_aias pythontests pytest -s "test/access_manager_tests.py::test_get_rasterio_session[gs://gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw]"
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests pytest -s "test/access_manager_tests.py"

--- a/test/tests_am.sh
+++ b/test/tests_am.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -o errexit
+echo "build docker image for tests"
+docker build -f docker/Dockerfile-tests . -t pythontests
+
+# Set env variable
+. ./test/env.sh
+
+docker ps
+
+echo "run test/access_manager_tests"
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests pytest -s test/access_manager_tests.py


### PR DESCRIPTION
This PR aims at providing a robust mecanism for checking that every access to resources through the AccessManager is checked against white lists for reading and writing.

The abstract storage has now a mecanism that intercepts all the function calls made on it or on its subclasses. It checks that the href parameter is whitelisted.

Main changes:
- add tests on the access manager: every method of the access manager that needs access authorization is tested. Each method has 2 tests: one to check that the function call is allowed when the access resource is whitelisted, one to check that the call is not allowed when the resource is not whitelisted. Note: the result of the method itself is not tested. This could go in a future tests implementation
- add new tests in the CI
- add accessed directories in the conf files
- in the access manager
   - a concept of "local storage" is added: it is the storage that uses `file` type
   - all the href provided in the functions must be full, like `https://mystorage/mybucket/path/to/my/file`
   - the access methods are moved  from the access manager (like `stream`)  to abstract storage: that class is responsible for checking the resource access.
- the abstract storage checks all the method calls if the method name does not start with `_`
   - there's is a whitelist for methods that do not need access control, like `get_gdal_stream_options`
   - the href parameter is extracted from other methods and confronted to the whitelisted pathes
- every storage implements it's own `is_path_authorized`

Side changes:
- type some function return (like creation date)
- 