### PR TITLE
Improve/async upload

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -62,7 +62,7 @@ class AbstractStorage(ABC):
                     return self._check_read_write_wrapper(fct, 0, AccessType.READ)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 1, AccessType.WRITE)
                 case "push":
                     return self._check_read_write_wrapper(fct, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
-                case "push_file_obj":
+                case "async_push_file_obj":
                     return self._check_read_write_wrapper(fct, 1, AccessType.WRITE)  # TODO need to solve circular import: and self._check_read_write_wrapper(AccessManager.get_local_storage(), attr, 0, AccessType.READ)
                 case _:
                     if name not in AbstractStorage.DO_NOT_PROTECT_METHODS:

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -6,6 +6,7 @@ from aias_common.access.file import File
 from aias_common.access.logger import Logger
 from aias_common.access.storages.abstract import AbstractStorage
 from fastapi_utilities import ttl_lru_cache
+import aioboto3
 
 from aias_common.access.storages.path_helper import endslash, join_pathes, noslash
 
@@ -51,6 +52,29 @@ class S3Storage(AbstractStorage):
             )
 
         return {"client": client}
+
+    def __aioboto3_client(self):
+        conf = self.get_configuration()
+        if conf.is_anon_client:
+            from botocore import UNSIGNED
+            from botocore.client import Config
+            session = aioboto3.Session()
+            client = session.client(
+                "s3",
+                region_name=conf.region,
+                endpoint_url=conf.endpoint,
+                config=Config(signature_version=UNSIGNED)
+            )
+        else:
+            session = aioboto3.Session()
+            client = session.client(
+                "s3",
+                region_name=conf.region,
+                endpoint_url=conf.endpoint,
+                aws_access_key_id=conf.api_key.access_key,
+                aws_secret_access_key=conf.api_key.secret_key,
+            )
+        return client
 
     def supports(self, href: str):
         scheme = urlparse(href).scheme
@@ -113,7 +137,7 @@ class S3Storage(AbstractStorage):
             extraArgs["ContentType"] = content_type
         client.upload_file(href, Bucket=self.get_configuration().bucket, Key=self.__get_href_key(dst), ExtraArgs=extraArgs)
 
-    def push_file_obj(self, file_obj, dst: str, content_type: str | None = None):
+    async def async_push_file_obj(self, file_obj, dst: str, content_type: str | None = None):
         """push source file like object on destination
 
         Args:
@@ -121,12 +145,12 @@ class S3Storage(AbstractStorage):
             dst (str): target destination for coping the content of file_obj
             content_type (str | None, optional): content type of the source file. Defaults to None.
         """
-        import botocore.client
-        client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
-        extraArgs = {}
+        extra_args = {}
         if content_type:
-            extraArgs["ContentType"] = content_type
-        client.upload_fileobj(file_obj, Bucket=self.get_configuration().bucket, Key=self.__get_href_key(dst), ExtraArgs=extraArgs)
+            extra_args["ContentType"] = content_type
+
+        async with self.__aioboto3_client() as s3:
+            await s3.upload_fileobj(file_obj, Bucket=self.get_configuration().bucket, Key=self.__get_href_key(dst), ExtraArgs=extra_args)
         
     @ttl_lru_cache(ttl=AbstractStorage.cache_tt, max_size=AbstractStorage.cache_size)
     def __head_object(self, href: str):

--- a/python/aias_common/requirements.txt
+++ b/python/aias_common/requirements.txt
@@ -5,5 +5,6 @@ google-cloud-storage==2.5.0
 pydantic==2.10.6
 requests==2.32.4
 smart_open==6.2.0
-boto3==1.24.89
+boto3==1.39.11
+aioboto3==15.1.0
 uvicorn==0.34.2

--- a/python/airs/core/product_registration.py
+++ b/python/airs/core/product_registration.py
@@ -77,9 +77,9 @@ def get_item_relative_path(collection: str, item_id: str) -> str:
     return os.path.join(collection, "items", item_id, item_id + ITEM_ARLAS_SUFFIX)
 
 
-def upload_asset(
+async def upload_asset(
     collection: str, item_id: str, asset_name: str, file_obj, content_type: str
-) -> str:
+):
     """upload the asset file to the configured S3
 
     Args:
@@ -97,7 +97,7 @@ def upload_asset(
         str: key, None if not uploaded
     """
     key = get_asset_relative_path(collection, item_id, asset_name)
-    return __upload_file(key, file_obj, content_type)
+    await __upload_file(key, file_obj, content_type)
 
 
 def delete_asset(collection: str, item_id: str, asset_name: str):
@@ -143,13 +143,12 @@ def __s3storage() -> S3Storage:
         api_key=S3ApiKey(access_key=Configuration.settings.s3.access_key_id, secret_key=Configuration.settings.s3.secret_access_key)))
 
 
-def __upload_file(key, file_obj, content_type) -> str:
+async def __upload_file(key, file_obj, content_type):
     try:
         LOGGER.info("uploading {} ...".format(key))
         dst = __s3storage().get_full_href(key)
-        __s3storage().push_file_obj(file_obj, dst, content_type)
+        await __s3storage().async_push_file_obj(file_obj, dst, content_type)
         LOGGER.info("{} uploaded.".format(key))
-        return key
     except Exception as e:
         msg = "Failed to upload {}".format(key)
         LOGGER.error(msg)

--- a/python/airs/requirements.txt
+++ b/python/airs/requirements.txt
@@ -1,5 +1,6 @@
 pygeohash==1.2.0
-boto3==1.24.89
+boto3==1.39.11
+aioboto3==15.1.0
 elasticsearch==8.9.0
 click==8.1.6
 typer==0.9.0

--- a/python/airs/rest/services.py
+++ b/python/airs/rest/services.py
@@ -15,7 +15,7 @@ __INVALID_ITEM_MSG__ = "Invalid items {}: {}"
 
 
 @ROUTER.post('/collections/{collection}/_init', description="Init a collection.")
-def init_collection(collection: str, request: Request) -> str:
+async def init_collection(collection: str, request: Request) -> str:
     if not collection:
         raise BadRequest(detail=__INVALID_COLLECTION_MSG__)
     return JSONResponse(content={"created": rs.init_collection(collection)},
@@ -24,7 +24,7 @@ def init_collection(collection: str, request: Request) -> str:
 
 
 @ROUTER.post('/collections/{collection}/items', description="Create an item. item.id must be set. Asset must exist (depends on the server configuration)")
-def create_item(collection: str, item: Item, request: Request) -> str:
+async def create_item(collection: str, item: Item, request: Request) -> str:
     """ From https://github.com/stac-api-extensions/transaction:
         POST
         When the body is a partial Item:
@@ -56,7 +56,7 @@ def create_item(collection: str, item: Item, request: Request) -> str:
 
 
 @ROUTER.put('/collections/{collection}/items/{id}', description="Update an item. Asset should/must exist (depends on the server configuration)")
-def update_item(collection: str, id: str, item: Item, request: Request) -> str:
+async def update_item(collection: str, id: str, item: Item, request: Request) -> str:
     """ From https://github.com/stac-api-extensions/transaction:
         PUT
         Must populate the id and collection fields in the Item from the URI.
@@ -89,7 +89,7 @@ def update_item(collection: str, id: str, item: Item, request: Request) -> str:
 
 
 @ROUTER.delete('/collections/{collection}/items/{id}', description="Delete an item and its assets (depends on the server configuration)")
-def delete_item(collection: str, id: str) -> str:
+async def delete_item(collection: str, id: str) -> str:
     """ From https://github.com/stac-api-extensions/transaction:
         DELETE
         Must return 200 or 204 for a successful operation.
@@ -108,7 +108,7 @@ def delete_item(collection: str, id: str) -> str:
 
 
 @ROUTER.get('/collections/{collection}/items/{id}', description="Retrieve an item")
-def get_item(collection: str, id: str) -> str:
+async def get_item(collection: str, id: str) -> str:
     if not rs.item_exists(collection, id):
         raise NotFound(detail="Item does not exist")
     try:
@@ -121,12 +121,9 @@ def get_item(collection: str, id: str) -> str:
 
 @ROUTER.post('/collections/{collection}/items/{item_id}/assets/{asset_name}', description="Upload an asset.")
 async def upload_asset(collection: str, item_id: str, asset_name: str, file: UploadFile = File(...)):
-    upload_obj = rs.upload_asset(collection=collection, item_id=item_id, asset_name=asset_name, file_obj=file.file, content_type=file.content_type)
-    if upload_obj:
-        return JSONResponse(content={"msg": "Object has been uploaded to bucket successfully"},
-                            status_code=status.HTTP_201_CREATED)
-    else:
-        raise ServerError(detail="File could not be uploaded")
+    await rs.upload_asset(collection=collection, item_id=item_id, asset_name=asset_name, file_obj=file.file, content_type=file.content_type)
+    return JSONResponse(content={"msg": "Object has been uploaded to bucket successfully"},
+                        status_code=status.HTTP_201_CREATED)
 
 
 @ROUTER.head('/collections/{collection}/items/{item_id}/assets/{asset_name}', description="Tests if an asset exists.")

--- a/python/airs/rest/services.py
+++ b/python/airs/rest/services.py
@@ -5,7 +5,7 @@ import airs.core.product_registration as rs
 from airs.core import exceptions
 from airs.core.models.mapper import to_json
 from airs.core.models.model import Item
-from aias_common.rest.exception import BadRequest, Conflict, NotFound, ServerError
+from aias_common.rest.exception import BadRequest, Conflict, NotFound
 
 ROUTER = APIRouter()
 

--- a/python/aproc/requirements.txt
+++ b/python/aproc/requirements.txt
@@ -16,5 +16,5 @@ jsonref==1.1.0
 ecs-logging==2.1.0
 PyJWT==2.8.0
 pillow==10.3.0
-boto3==1.24.89
+boto3==1.39.11
 fastapi-utilities==0.3.1

--- a/python/extensions/requirements.ext.txt
+++ b/python/extensions/requirements.ext.txt
@@ -4,7 +4,7 @@ shapely==2.1.0
 pyproj==3.7.1
 PyJWT==2.8.0
 pillow==10.3.0
-boto3==1.24.89
+boto3==1.39.11
 smart_open==7.1.0
 zarr==2.18.7
 xarray[io]==2024.9.0

--- a/python/extensions/requirements.storage.txt
+++ b/python/extensions/requirements.storage.txt
@@ -2,4 +2,5 @@ google-cloud-storage==2.5.0
 pydantic==2.10.6
 requests==2.32.4
 smart_open==7.1.0
-boto3==1.24.89
+boto3==1.39.11
+aioboto3==15.1.0

--- a/release/materials/aias_common/setup.py
+++ b/release/materials/aias_common/setup.py
@@ -14,5 +14,5 @@ setuptools.setup(
     python_requires='>=3.10',
     package_dir={'': 'src'},
     install_requires=['ecs_logging', 'google-cloud-storage==2.5.0', 'pydantic==2.10.6', 'requests==2.32.4',
-                      'smart_open==6.2.0', 'boto3==1.24.89', 'fastapi_utilities']
+                      'smart_open==6.2.0', 'boto3==1.39.11', 'fastapi_utilities']
 )

--- a/test/access_manager_tests.py
+++ b/test/access_manager_tests.py
@@ -1,4 +1,3 @@
-from time import sleep
 import os
 import pytest
 from aias_common.access.configuration import AccessManagerSettings, HttpsStorageConfiguration

--- a/test/access_manager_tests.py
+++ b/test/access_manager_tests.py
@@ -1,3 +1,4 @@
+from time import sleep
 import os
 import pytest
 from aias_common.access.configuration import AccessManagerSettings, HttpsStorageConfiguration
@@ -304,16 +305,16 @@ def test_not_push(fixture_am, href: str):
 
 
 @pytest.mark.parametrize("href", CAN_PUSH_ON)
-def test_push_fo(fixture_am, fixture_objectstore: s3.S3Storage, href: str):
+async def test_push_fo(fixture_am, fixture_objectstore: s3.S3Storage, href: str):
     with open(FS_RO_FILE, 'rb') as fo:
-        fixture_objectstore.push_file_obj(fo, href)
+        await fixture_objectstore.async_push_file_obj(fo, href)
 
 
 @pytest.mark.parametrize("href", CAN_NOT_WRITE)
 def test_not_push_fo(fixture_am, fixture_objectstore: s3.S3Storage, href: str):
     with pytest.raises(PermissionError):
         with open(FS_RO_FILE, 'rb') as fo:
-            fixture_objectstore.push_file_obj(fo, href)
+            fixture_objectstore.async_push_file_obj(fo, href)
 
 
 ###########################
@@ -457,4 +458,3 @@ def test_zip(fixture_am, href: str):
 def test_zip_fail(fixture_am, href: str):
     with pytest.raises(PermissionError):
         manager.AccessManager.zip(href, FS_RW_DIR_SLASH + "file.zip")
-

--- a/test/airs_tests.py
+++ b/test/airs_tests.py
@@ -36,8 +36,8 @@ class Tests(unittest.TestCase):
         f = open(ASSET_PATH, 'rb')
         file = {'file': (ASSET, f, "image/tiff")}
         r = requests.post(url=os.path.join(AIRS_URL, "collections", COLLECTION, "items", ID_MANAGED, "assets", ASSET), files=file)
-        self.assertTrue(r.ok, str(r.status_code) + str(r.content))
         f.close()
+        self.assertTrue(r.ok, str(r.status_code) + str(r.content))
         # ASSET FOUND
         r = requests.head(url=os.path.join(AIRS_URL, "collections", COLLECTION, "items", ID_MANAGED, "assets", ASSET))
         self.assertTrue(r.ok, str(r.status_code) + str(r.content))

--- a/test/airs_tests.py
+++ b/test/airs_tests.py
@@ -33,11 +33,10 @@ class Tests(unittest.TestCase):
 
     def test_upload(self):
         # UPLOAD ASSET
-        f = open(ASSET_PATH, 'rb')
-        file = {'file': (ASSET, f, "image/tiff")}
-        r = requests.post(url=os.path.join(AIRS_URL, "collections", COLLECTION, "items", ID_MANAGED, "assets", ASSET), files=file)
-        f.close()
-        self.assertTrue(r.ok, str(r.status_code) + str(r.content))
+        with open(ASSET_PATH, 'rb') as f:
+            file = {'file': (ASSET, f, "image/tiff")}
+            r = requests.post(url=os.path.join(AIRS_URL, "collections", COLLECTION, "items", ID_MANAGED, "assets", ASSET), files=file)
+            self.assertTrue(r.ok, str(r.status_code) + str(r.content))
         # ASSET FOUND
         r = requests.head(url=os.path.join(AIRS_URL, "collections", COLLECTION, "items", ID_MANAGED, "assets", ASSET))
         self.assertTrue(r.ok, str(r.status_code) + str(r.content))

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,5 @@
-boto3==1.24.89
+boto3==1.39.11
+aioboto3==15.1.0
 elasticsearch==8.9.0
 pydantic==2.10.6
 python-dateutil==2.8.2
@@ -17,3 +18,4 @@ pillow==10.3.0
 typer==0.9.0
 fastapi-utilities==0.3.1
 pytest==8.4.2
+pytest-asyncio==0.22.0


### PR DESCRIPTION
currently, the upload is synchrone. When uploading large files, the service becomes unresponsive, including for healthchecks, this makes k8s restarting the pod :-(
This PR propose asynchronous method instead.
