### PR TITLE
openid uri->jwks uri

### DIFF
--- a/conf/agate.yaml
+++ b/conf/agate.yaml
@@ -27,7 +27,7 @@ services:
         part: query.url.url.path # takes the query parametters, use it as a url, then extract the path
 urbac:
   role_file: conf/roles.yaml
-  open_id_provider: $OPEN_ID_PROVIDER|
+  jwks_uri: $JWKS_URI|
   verify_jwt: $VERIFY_JWT|true
   verify_ssl: $VERIFY_SSL|true
   jwt_audience: arlas-backend

--- a/python/agate/cli/agate.py
+++ b/python/agate/cli/agate.py
@@ -36,10 +36,10 @@ def run(configuration_file: str = typer.Argument(..., help="Configuration file")
     if not Configuration.settings.urbac.verify_jwt:
         LOGGER.warning("JWT verification is disabled, this should never be the case in production.")
     else:
-        if Configuration.settings.urbac.open_id_provider:
+        if Configuration.settings.urbac.jwks_uri:
             if not Configuration.settings.urbac.verify_ssl:
                 LOGGER.warning("SSL verification is disabled, this should never be the case in production.")
-            Authorizations.load_keys_from_openid_configuration(Configuration.settings.urbac.open_id_provider, Configuration.settings.urbac.verify_ssl)
+            Authorizations.load_keys_from_jwks_uri(Configuration.settings.urbac.jwks_uri, Configuration.settings.urbac.verify_ssl)
         else:
             raise Exception("JWT verification is enabled but no Open ID Provider provided, JWT won't be accepted.")
     uvicorn.run(api, host=Configuration.settings.host, port=Configuration.settings.port)

--- a/python/agate/rest/authorizations.py
+++ b/python/agate/rest/authorizations.py
@@ -13,36 +13,27 @@ class Authorizations:
     keys: dict = {}
 
     @staticmethod
-    def load_keys_from_openid_configuration(uri: str, verify_ssl: bool = True):
-        """ Retrieve the JWKS from the OpenID configuration located at uri and return a dictionary of keys indexed by their kid.
+    def load_keys_from_jwks_uri(jwks_uri: str, verify_ssl: bool = True):
+        """ Retrieve the JWKS from the uri and return a dictionary of keys indexed by their kid.
 
         Args:
-            uri (str): The OpenID configuration uri (e.g. https://accounts.google.com/.well-known/openid-configuration)
+            jwks_uri (str): The JWKS uri (e.g. https://www.googleapis.com/oauth2/v3/certs)
 
         Raises:
-            Exception: If the OpenID configuration or the JWKS can not be retrieved.
+            Exception: If the JWKS can not be retrieved.
 
         Returns:
             dict: A dictionary of keys indexed by their kid.
         """
-        LOGGER.debug(f"Retrieving OpenID configuration from {uri}")
-        r = requests.get(uri, verify=verify_ssl)
+        r = requests.get(jwks_uri, verify=verify_ssl)
         if r.status_code == 200:
-            jwks_uri = r.json().get("jwks_uri")
-            if jwks_uri:
-                r = requests.get(jwks_uri, verify=verify_ssl)
-                if r.status_code == 200:
-                    jwks = r.json()
-                    LOGGER.debug(f"Loading JWKS from {jwks_uri}")
-                    from jwt.algorithms import RSAAlgorithm
-                    for e in jwks.get("keys", []):
-                        Authorizations.keys[e['kid']] = RSAAlgorithm.from_jwk(e)
-                else:
-                    raise Exception(f"Unable to retrieve JWKS from {jwks_uri}, status code {r.status_code}")
-            else:
-                raise Exception(f"No jwks_uri found in the OpenID configuration from {uri}")
+            jwks = r.json()
+            LOGGER.debug(f"Loading JWKS from {jwks_uri}")
+            from jwt.algorithms import RSAAlgorithm
+            for e in jwks.get("keys", []):
+                Authorizations.keys[e['kid']] = RSAAlgorithm.from_jwk(e)
         else:
-            raise Exception(f"Unable to retrieve JWKS from {uri}, status code {r.status_code}")
+            raise Exception(f"Unable to retrieve JWKS from {jwks_uri}, status code {r.status_code}")
 
     @staticmethod
     def get_user_roles(authorization: str) -> list[str]:

--- a/python/agate/settings.py
+++ b/python/agate/settings.py
@@ -29,7 +29,7 @@ class URBAC(BaseModel, extra=Extra.allow):
     roles: Roles = Field(default=Roles(technicalRoles={}), title="Roles", description="Definition of the endpoints and of the authorized roles. This is automatically filled from role_file")
     role_file: str = Field(title="Role file", description="File location containing the roles")
     verify_jwt: bool = Field(True, title="Verify JWT", description="Whether to verify the JWT signature. Should be True in production.")
-    open_id_provider: str | None = Field("", title="Open ID Provider url", description="Must be provided for production. Open ID Provider url (ex https://keycloak.example.com/auth/realms/master/.well-known/openid-configuration).")
+    jwks_uri: str | None = Field("", title="jwks url", description="Must be provided for production.")
     verify_ssl: bool = Field(True, title="Verify SSL", description="Whether to verify SSL certificates when fetching the OpenID configuration and JWKS. Should be True in production.")
     jwt_audience: str = Field("", title="JWT Audience", description="Expected audience in the JWT. If not set, no audience verification is done.")
     jwt_header: str = Field("authorization", title="JWT header name", description="The name of the header parameter containing the JWT")


### PR DESCRIPTION
Change the configuration of agate so that we do not provide the openid url but the jwks uri instead, for future compatibility with arlas iam