### PR TITLE
aproc ping and agate logs

### DIFF
--- a/docker/materials/scripts/aproc-proc/ping.sh
+++ b/docker/materials/scripts/aproc-proc/ping.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 set -o errexit -o pipefail
 
+EXTRA_OPT=""
+if [ -z "$BROKER" ]
+then
+    echo "Using default broker"
+else
+    echo "Using provided broker $BROKER"
+    EXTRA_OPT="-b "`echo $BROKER | sed 's/pyamqp:\/\//amqp:\/\//'`
+fi
+
 . aproc/bin/activate
-celery inspect ping --destination worker@$HOSTNAME
+celery $EXTRA_OPT inspect ping --destination worker@$HOSTNAME

--- a/python/agate/rest/service.py
+++ b/python/agate/rest/service.py
@@ -19,14 +19,17 @@ async def urbac(request: Request):
 
     authorization = request.headers.get(Configuration.settings.urbac.jwt_header)
     if not authorization:
+        LOGGER.debug("{} not found in headers".format(Configuration.settings.urbac.jwt_header))
         return Response(status_code=status.HTTP_401_UNAUTHORIZED, content=MISSING_MSG.format(Configuration.settings.urbac.jwt_header))
 
     request_path = request.headers.get(Configuration.settings.url_header)
-    if not authorization:
+    if not request_path:
+        LOGGER.debug("{} not found in headers".format(Configuration.settings.url_header))
         return Response(status_code=status.HTTP_401_UNAUTHORIZED, content=MISSING_MSG.format(Configuration.settings.url_header))
 
     request_method = request.headers.get(Configuration.settings.method_header)
     if not request_method:
+        LOGGER.debug("{} not found in headers".format(Configuration.settings.method_header))
         return Response(status_code=status.HTTP_401_UNAUTHORIZED, content=MISSING_MSG.format(Configuration.settings.method_header))
     LOGGER.debug("Incoming request: {} on {}".format(request_method, request_path))
 

--- a/python/aproc/core/processes/processes.py
+++ b/python/aproc/core/processes/processes.py
@@ -31,6 +31,8 @@ APROC_CELERY_APP = Celery(
     name='aproc',
     broker=Configuration.settings.celery_broker_url,
     backend=Configuration.settings.celery_result_backend)
+LOGGER.debug("Celery broker: {}".format(Configuration.settings.celery_broker_url))
+LOGGER.debug("Celery backend: {}".format(Configuration.settings.celery_result_backend))
 
 APROC_JOBS_INDEX="idx:aproc_jobs"
 
@@ -58,14 +60,15 @@ class Processes:
                     else:
                         status_info.status = Processes.__to_status_info_code__(event.get('state'))
                         status_info.updated = round(datetime.now().timestamp())
+                        res = AsyncResult(task_id, app=APROC_CELERY_APP)
                         if status_info.status.is_final():
                             status_info.finished = round(datetime.now().timestamp())
-                            if event.get('state') == states.SUCCESS:
-                                status_info.message = json.dumps(AsyncResult(task_id).result, default=serialize_datetime)
+                            if res.status == states.SUCCESS:
+                                status_info.message = json.dumps(AsyncResult(task_id, app=APROC_CELERY_APP).result, default=serialize_datetime)
                             else:
-                                status_info.message = str(AsyncResult(task_id).result)
+                                status_info.message = str(AsyncResult(task_id, app=APROC_CELERY_APP).result)
                         else:
-                            if event.get('state') == states.STARTED:
+                            if res.status == states.STARTED:
                                 status_info.started = round(datetime.now().timestamp())
                         Processes.__save_status_info__(status_info)
                 else:

--- a/python/aproc/core/processes/processes.py
+++ b/python/aproc/core/processes/processes.py
@@ -27,7 +27,10 @@ LOGGER = Logger.logger
 LOGGER.info("Loading configuration {}".format(os.environ.get("APROC_CONFIGURATION_FILE")))
 Configuration.init(os.environ.get("APROC_CONFIGURATION_FILE"))
 AccessManager.init(Configuration.settings.access_manager)
-APROC_CELERY_APP = Celery(name='aproc', broker=Configuration.settings.celery_broker_url, backend=Configuration.settings.celery_result_backend)
+APROC_CELERY_APP = Celery(
+    name='aproc',
+    broker=Configuration.settings.celery_broker_url,
+    backend=Configuration.settings.celery_result_backend)
 
 APROC_JOBS_INDEX="idx:aproc_jobs"
 


### PR DESCRIPTION
**Before:**
- the healthcheck for aproc worker was working with the default broker url. It is different, the healthcheck doesn't work
- agate has a wrong test for checking that the url header is provided

**After:**
- add a configurable broker url for the aproc healthcheck (ping)
- fix url header test in agate