### PR TITLE
add redis sentinel configuration

### DIFF
--- a/conf/aproc.yaml
+++ b/conf/aproc.yaml
@@ -1,5 +1,15 @@
-celery_broker_url: $CELERY_BROKER_URL|pyamqp://guest:guest@127.0.0.1:5672//
-celery_result_backend: $CELERY_RESULT_BACKEND|redis://127.0.0.1:6379/0
+
+celery_broker_url: pyamqp://guest:guest@rabbitmq:5672//
+
+# Redis connection with a sentinel:               
+celery_result_backend: sentinel://sentinel1:26379;sentinel://sentinel2:26379;sentinel://sentinel3:26379
+celery_result_backend_transport_options:
+   master_name: mymaster
+#   sentinel_password: your-strong-password
+
+# alternatively, without sentinels: 
+# celery_result_backend: redis://redis-master:6379
+
 airs_endpoint: $AIRS_ENDPOINT|http://127.0.0.1:8000/arlas/airs
 processes:
   -

--- a/docker/compose/docker-compose.yaml
+++ b/docker/compose/docker-compose.yaml
@@ -55,6 +55,20 @@ services:
       timeout: 30s
       retries: 10
 
+  flower:
+    image: mher/flower:1.2.0
+    container_name: flower
+    environment:
+      - CELERY_BROKER_URL=pyamqp://guest:guest@rabbitmq:5672//
+      - FLOWER_PORT=5555
+      - FLOWER_BASIC_AUTH=admin:your_flower_password
+    ports:
+      - "5555:5555"
+    networks:
+      - aias
+    depends_on:
+      - redis-master
+
   smtp4dev:
     image: rnwood/smtp4dev:linux-${PLATFORM}-3.2.0-ci20221023104
     platform: linux/${PLATFORM}
@@ -67,15 +81,110 @@ services:
       #Specifies the server hostname. Used in auto-generated TLS certificate if enabled.
       - ServerOptions__HostName=smtp4dev
 
-  redis:
-    image: redis/redis-stack:${REDIS_VERSION:-7.2.0-v2}
+  # redis:
+  #   image: redis/redis-stack:${REDIS_VERSION:-7.2.0-v2}
+  #   networks:
+  #     - aias
+  #   container_name: redis
+  #   ports:
+  #     - 6379:6379
+  #   healthcheck:
+  #     test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+  # Redis Master
+  redis-master:
+    container_name: redis-master
+    image: redis:latest
+    command: ["redis-server", "--appendonly", "yes", "--protected-mode", "no"]
     networks:
       - aias
-    container_name: redis
-    ports:
-      - 6379:6379
+
+  redis-slave-1:
+    container_name: redis-slave-1
+    image: redis:latest
+    depends_on:
+      - redis-master
+    command: ["redis-server", "--replicaof", "redis-master", "6379", "--protected-mode", "no"]
+    networks:
+      - aias
+
+  redis-slave-2:
+    container_name: redis-slave-2
+    image: redis:latest
+    depends_on:
+      - redis-master
+    command: ["redis-server", "--replicaof", "redis-master", "6379", "--protected-mode", "no"]
+    networks:
+      - aias
+
+  redis-slave-3:
+    container_name: redis-slave-3
+    image: redis:latest
+    depends_on:
+      - redis-master
+    command: ["redis-server", "--replicaof", "redis-master", "6379", "--protected-mode", "no"]
+    networks:
+      - aias
+
+  sentinel1:
+    container_name: sentinel1
+    image: redis:latest
+    depends_on:
+      - redis-master
+      - redis-slave-1
+      - redis-slave-2
+      - redis-slave-3
+    command: >
+      sh -c 'echo "sentinel resolve-hostnames yes" > /etc/sentinel.conf &&
+            echo "sentinel monitor mymaster redis-master 6379 2" >> /etc/sentinel.conf &&
+            echo "sentinel down-after-milliseconds mymaster 1000" >> /etc/sentinel.conf &&
+            echo "sentinel failover-timeout mymaster 5000" >> /etc/sentinel.conf &&
+            echo "sentinel parallel-syncs mymaster 1" >> /etc/sentinel.conf &&
+            redis-server /etc/sentinel.conf --sentinel'
+    networks:
+      - aias
     healthcheck:
-      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+      test: ["CMD", "redis-cli", "-p", "26379", "PING"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+
+  sentinel2:
+    container_name: sentinel2
+    image: redis:latest
+    depends_on:
+      - redis-master
+      - redis-slave-1
+      - redis-slave-2
+      - redis-slave-3
+    command: >
+      sh -c 'echo "sentinel resolve-hostnames yes" > /etc/sentinel.conf &&
+            echo "sentinel monitor mymaster redis-master 6379 2" >> /etc/sentinel.conf &&
+            echo "sentinel down-after-milliseconds mymaster 1000" >> /etc/sentinel.conf &&
+            echo "sentinel failover-timeout mymaster 5000" >> /etc/sentinel.conf &&
+            echo "sentinel parallel-syncs mymaster 1" >> /etc/sentinel.conf &&
+            redis-server /etc/sentinel.conf --sentinel'
+    networks:
+      - aias
+
+  sentinel3:
+    container_name: sentinel3
+    image: redis:latest
+    depends_on:
+      - redis-master
+      - redis-slave-1
+      - redis-slave-2
+      - redis-slave-3
+    command: >
+      sh -c 'echo "sentinel resolve-hostnames yes" > /etc/sentinel.conf &&
+            echo "sentinel monitor mymaster redis-master 6379 2" >> /etc/sentinel.conf &&
+            echo "sentinel down-after-milliseconds mymaster 1000" >> /etc/sentinel.conf &&
+            echo "sentinel failover-timeout mymaster 5000" >> /etc/sentinel.conf &&
+            echo "sentinel parallel-syncs mymaster 1" >> /etc/sentinel.conf &&
+            redis-server /etc/sentinel.conf --sentinel'
+    networks:
+      - aias
 
   airs-server:
     networks:
@@ -138,8 +247,6 @@ services:
       - APROC_ENDPOINT_FROM_APROC=$APROC_ENDPOINT_FROM_APROC
       - ARLAS_URL_SEARCH=$ARLAS_URL_SEARCH
       - APROC_CONFIGURATION_FILE=/app/conf/aproc.yaml
-      - CELERY_BROKER_URL=pyamqp://guest:guest@rabbitmq:5672//
-      - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - AIRS_ENDPOINT=http://airs-server:8000/arlas/airs
       - AIRS_INDEX_COLLECTION_PREFIX=${AIRS_INDEX_COLLECTION_PREFIX:-airs}
       - ARLAS_SMTP_ACTIVATED=${ARLAS_SMTP_ACTIVATED}
@@ -188,7 +295,7 @@ services:
       - ${PWD}/test/inputs:/inputs:ro
       - ${PWD}/outbox/:/outbox:wr
     depends_on:
-      redis:
+      sentinel1:
           condition: service_healthy
       rabbitmq:
           condition: service_healthy
@@ -204,7 +311,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-      redis:
+      sentinel1:
           condition: service_healthy
       rabbitmq:
           condition: service_healthy
@@ -216,8 +323,6 @@ services:
       - APROC_CORS_METHODS=${APROC_CORS_METHODS:-*}
       - APROC_CORS_HEADERS=${APROC_CORS_HEADERS:-*}
       - APROC_CONFIGURATION_FILE=/app/conf/aproc.yaml
-      - CELERY_BROKER_URL=pyamqp://guest:guest@rabbitmq:5672//
-      - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - AIRS_ENDPOINT=http://airs-server:8000/arlas/airs
       - AIRS_INDEX_COLLECTION_PREFIX=${AIRS_INDEX_COLLECTION_PREFIX:-airs}
       - ARLAS_SMTP_ACTIVATED=${ARLAS_SMTP_ACTIVATED}
@@ -320,3 +425,9 @@ services:
       - APROC_CONFIGURATION_FILE=/app/conf/aproc.yaml
     ports:
       - "8007:8005"
+
+
+volumes:
+  redis-master-data:
+  redis-replica1-data:
+  redis-replica2-data:

--- a/python/aproc/core/processes/processes.py
+++ b/python/aproc/core/processes/processes.py
@@ -10,6 +10,7 @@ from celery import Celery, states
 from celery.result import AsyncResult
 from pydantic import BaseModel
 from redis import Redis
+from redis.sentinel import Sentinel
 from redis.commands.search.field import NumericField, TagField, TextField
 from redis.commands.search.indexDefinition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
@@ -27,20 +28,22 @@ LOGGER = Logger.logger
 LOGGER.info("Loading configuration {}".format(os.environ.get("APROC_CONFIGURATION_FILE")))
 Configuration.init(os.environ.get("APROC_CONFIGURATION_FILE"))
 AccessManager.init(Configuration.settings.access_manager)
+
+LOGGER.debug("Celery broker: {}".format(Configuration.settings.celery_broker_url))
+LOGGER.debug("Celery backend: {}".format(Configuration.settings.celery_result_backend))
+LOGGER.debug("Celery backend transport options: {}".format(Configuration.settings.celery_result_backend_transport_options))
+
 APROC_CELERY_APP = Celery(
     name='aproc',
     broker=Configuration.settings.celery_broker_url,
-    backend=Configuration.settings.celery_result_backend)
-LOGGER.debug("Celery broker: {}".format(Configuration.settings.celery_broker_url))
-LOGGER.debug("Celery backend: {}".format(Configuration.settings.celery_result_backend))
+    backend=Configuration.settings.celery_result_backend,
+    result_backend_transport_options=Configuration.settings.celery_result_backend_transport_options)
 
 APROC_JOBS_INDEX="idx:aproc_jobs"
-
 
 class Processes:
     processes: list[Process] = []
     __REDIS_PREFIX__ = "airs_job_id:"
-    __REDIS_CONNECTION__: Redis = None
 
     @staticmethod
     def __listen_status__():
@@ -302,22 +305,39 @@ class Processes:
 
     @staticmethod
     def __get_redis_client__() -> Redis:
-        if Processes.__REDIS_CONNECTION__ is None:
-            uri = urlparse(Configuration.settings.celery_result_backend)
-            if uri.scheme == "redis":
-                params = {
-                    "host": uri.hostname,
-                    "port": uri.port,
-                    "decode_responses": True
-                }
-                if uri.username:
-                    params["username"] = uri.username
-                if uri.password:
-                    params["password"] = uri.password
-                Processes.__REDIS_CONNECTION__ = Redis(**params)
-            else:
-                raise Exception("Unsupported backend {}".format(uri.scheme))
-        return Processes.__REDIS_CONNECTION__
-
+        uri = urlparse(Configuration.settings.celery_result_backend)
+        if uri.scheme == "redis":
+            params = {
+                "host": uri.hostname,
+                "port": uri.port,
+                "decode_responses": True
+            }
+            if uri.username:
+                params["username"] = uri.username
+            if uri.password:
+                params["password"] = uri.password
+            LOGGER.debug(f"Using directly redis: {params}")
+            return Redis(**params)
+        elif uri.scheme == "sentinel":
+            LOGGER.debug(f"Using sentinels for retrieving redis master")
+            celery_result_backend_transport_options = Configuration.settings.celery_result_backend_transport_options
+            if celery_result_backend_transport_options is None or celery_result_backend_transport_options.get("master_name") is None:
+                raise Exception("Invalid configuration: master_name and sentinel_password must be provided")
+            
+            sentinels: list[tuple[str, int]] = [(urlparse(s).hostname, urlparse(s).port) for s in Configuration.settings.celery_result_backend.split(";")]
+            LOGGER.debug(f"Fetching master from sentinels {sentinels}")
+            host, port = Sentinel(sentinels).discover_master(Configuration.settings.celery_result_backend_transport_options.get("master_name"))
+            LOGGER.debug(f"Connect to {host}:{port}")
+            con = {
+                "host": host,
+                "port": port,
+                "decode_responses": True,
+            }
+            pwd = celery_result_backend_transport_options.get("sentinel_password", "")
+            if pwd:
+                con["password"] = pwd
+            return Redis(**con)
+        else:
+            raise Exception("Unsupported backend {}".format(uri.scheme))
 
 Processes.init()

--- a/python/aproc/core/processes/processes.py
+++ b/python/aproc/core/processes/processes.py
@@ -319,10 +319,10 @@ class Processes:
             LOGGER.debug(f"Using directly redis: {params}")
             return Redis(**params)
         elif uri.scheme == "sentinel":
-            LOGGER.debug(f"Using sentinels for retrieving redis master")
+            LOGGER.debug("Using sentinels for retrieving redis master")
             celery_result_backend_transport_options = Configuration.settings.celery_result_backend_transport_options
             if celery_result_backend_transport_options is None or celery_result_backend_transport_options.get("master_name") is None:
-                raise Exception("Invalid configuration: master_name and sentinel_password must be provided")
+                raise ConnectionError("Invalid configuration: master_name and sentinel_password must be provided")
             
             sentinels: list[tuple[str, int]] = [(urlparse(s).hostname, urlparse(s).port) for s in Configuration.settings.celery_result_backend.split(";")]
             LOGGER.debug(f"Fetching master from sentinels {sentinels}")

--- a/python/aproc/core/settings.py
+++ b/python/aproc/core/settings.py
@@ -14,8 +14,9 @@ class ProcessSettings(BaseModel, extra='allow'):
 
 
 class Settings(BaseModel, extra='allow'):
-    celery_broker_url: str | None = Field(title="Celery's broker url", description="Celery's broker url of the form of transport://userid:password@hostname:port/virtual_host")
-    celery_result_backend: str | None = Field(title="Celery's backend", description="Celery's backend used to store task results")
+    celery_broker_url: str = Field(title="Celery's broker url", description="Celery's broker url of the form of transport://userid:password@hostname:port/virtual_host")
+    celery_result_backend: str = Field(title="Celery's backend", description="Celery's backend used to store task results")
+    celery_result_backend_transport_options: dict | None = Field({}, title="Transport options", description="Celery's result backend transport options", examples="master_name: mymaster and sentinel_password: your-strong-password")
     processes: list[ProcessSettings] = Field(title="List of processes", description="List of APROC processes")
     airs_endpoint: str | None = Field(title="AIRS endpoint", description="ARLAS Item Registration Service endpoint")
     access_manager: AccessManagerSettings = Field(title="AccessManager configuration", description="Configuration for the AccessManager")


### PR DESCRIPTION
**Before:**
- the celery was connecting to redis with a direct connection, without extra params needed for sentinel connection
- the redis client was connecting to redis with a direct connection and was not supporting multiple sentinel uris

**After:**
- celery accepts extra params for backend connection, allowing sentinel connection for redis
- the redis client accepts sentinel urls
- the redis get_client returns always a new client since it can change over time
- the test stack uses sentinels