### PR TITLE
Feat/fixfamwui

### DIFF
--- a/angular/file-explorer/scripts/start.sh
+++ b/angular/file-explorer/scripts/start.sh
@@ -58,4 +58,68 @@ set_default_env_variable "AIRS_SERVER_URL" "https://localhost:81/airs"
 set_default_env_variable "AIRS_COLLECTION" "digitalearth.africa"
 
 
+
+
+
+SETTINGS_VARS="FAM_WUI_APP_PATH
+    FAM_WUI_BASE_HREF
+    ARLAS_STATIC_LINKS
+    ARLAS_USE_AUTHENT
+    ARLAS_AUTHENT_FORCE_CONNECT
+    ARLAS_AUTHENT_USE_DISCOVERY
+    ARLAS_AUTHENT_ISSUER
+    ARLAS_AUTHENT_CLIENT_ID
+    ARLAS_AUTHENT_REDIRECT_URI
+    ARLAS_AUTHENT_SILENT_REFRESH_REDIRECT_URI
+    ARLAS_AUTHENT_SCOPE
+    ARLAS_AUTHENT_TOKEN_ENDPOINT
+    ARLAS_AUTHENT_USERINFO_ENDPOINT
+    ARLAS_AUTHENT_JWKS_ENDPOINT
+    ARLAS_AUTHENT_LOGIN_URL
+    ARLAS_AUTHENT_LOGOUT_URL
+    ARLAS_AUTHENT_SHOW_DEBUG
+    ARLAS_AUTHENT_REQUIRE_HTTPS
+    ARLAS_AUTHENT_RESPONSE_TYPE
+    ARLAS_AUTHENT_SILENT_REFRESH_TIMEOUT
+    ARLAS_AUTHENT_TIMEOUT_FACTOR
+    ARLAS_AUTHENT_ENABLE_SESSION_CHECKS
+    ARLAS_AUTHENT_CLEAR_HASH
+    ARLAS_AUTHENT_STORAGE
+    ARLAS_AUTHENT_DISABLE_AT_HASH_CHECK
+    ARLAS_AUTHENT_DUMMY_CLIENT_SECRET
+    ARLAS_AUTHENT_CUSTOM_QUERY_PARAMS
+    ARLAS_AUTHENT_MODE
+    ARLAS_AUTHENT_THRESHOLD
+    ARLAS_AUTHENT_SIGN_UP_ENABLED
+    ARLAS_IAM_SERVER_URL
+    FAM_SERVER_URL
+    FAM_DEFAULT_PATH
+    FAM_COLLECTION
+    FAM_ARCHIVES_PAGES_SIZE
+    FAM_FILES_PAGES_SIZE
+    APROC_SERVER_URL
+    APROC_CATALOG
+    APROC_COLLECTION
+    AIRS_SERVER_URL
+    AIRS_COLLECTION"
+
+SETTINGS_SUBST=$(printf '$%s ' $SETTINGS_VARS)
+envsubst "$SETTINGS_SUBST" < /usr/share/nginx/html/settings.yaml > /usr/share/nginx/html/settings.yaml.tmp
+truncate -s 0 /usr/share/nginx/html/settings.yaml
+cat /usr/share/nginx/html/settings.yaml.tmp >> /usr/share/nginx/html/settings.yaml
+
+# Variables to substitute in index.html
+INDEX_VARS="FAM_WUI_BASE_HREF"
+
+INDEX_SUBST=$(printf '$%s ' $INDEX_VARS)
+envsubst "$INDEX_SUBST" < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.tmp
+cat /usr/share/nginx/html/index.html.tmp > /usr/share/nginx/html/index.html
+
+# Variables to substitute in nginx default.conf
+NGINX_VARS="FAM_WUI_APP_PATH"
+
+NGINX_SUBST=$(printf '$%s ' $NGINX_VARS)
+envsubst "$NGINX_SUBST" < /etc/nginx/conf.d/default.conf > /etc/nginx/conf.d/default.conf.tmp
+cat /etc/nginx/conf.d/default.conf.tmp > /etc/nginx/conf.d/default.conf
+
 nginx -g "daemon off;"

--- a/angular/file-explorer/src/app/components/drivers-dialog/drivers-dialog.component.html
+++ b/angular/file-explorer/src/app/components/drivers-dialog/drivers-dialog.component.html
@@ -7,7 +7,7 @@
 
 <mat-dialog-actions class="actions">
   <button mat-flat-button color="primary" [color]="'primary'" [mat-dialog-close]="{drivers: selectedDrivers}">
-    {{'Save' | translate}}
+    {{'Ok' | translate}}
   </button>
   <button mat-stroked-button [mat-dialog-close]="false">
     {{'Cancel' | translate}}

--- a/angular/file-explorer/src/app/components/drivers-list/drivers-list.component.ts
+++ b/angular/file-explorer/src/app/components/drivers-list/drivers-list.component.ts
@@ -21,7 +21,7 @@ export class DriversListComponent implements OnInit {
     const storedDrivers = localStorage.getItem('driversActivated') ? localStorage.getItem('driversActivated').split(',') : [];
     this.selectedDrivers.emit(storedDrivers);
     this.availalbleDrivers = this.jobService.availableDrivers.map(driver => {
-      let selected = storedDrivers.includes(driver) ?? false
+      let selected = storedDrivers.includes(driver) ?? true
       return { name: driver, selected }
     });
   }

--- a/angular/file-explorer/src/app/components/home/home.component.html
+++ b/angular/file-explorer/src/app/components/home/home.component.html
@@ -2,7 +2,7 @@
   <div left-menu>{{'Archive explorer' | translate}}</div>
   <div right-menu class="right-menu">
     <button class="right-menu--btn" mat-icon-button [disableRipple]="true" (click)="openDrivers()" [matTooltip]="'Enable drivers' | translate">
-        <mat-icon>storage</mat-icon>
+        <mat-icon>extension</mat-icon>
     </button>
     <button class="right-menu--btn" mat-icon-button (click)="refresh()" [matTooltip]="'Refresh' | translate">
         <mat-icon>refresh</mat-icon>

--- a/angular/file-explorer/src/app/services/fam/fam.service.ts
+++ b/angular/file-explorer/src/app/services/fam/fam.service.ts
@@ -60,7 +60,7 @@ export class FamService {
   }
 
   public getArchive(path: string, drivers: string[] = []): Observable<Archive[]> {
-    return this.http.post(this.famSettings?.url + '/archives', { path, size: this.famSettings?.archives_page_size, included_drivers: drivers }, this.options) as Observable<Archive[]>;
+    return this.http.post(this.famSettings?.url + '/archives', { path, size: this.famSettings?.archives_page_size, include_drivers: drivers }, this.options) as Observable<Archive[]>;
   }
 
   public initializeFiles(path: string) {

--- a/angular/file-explorer/src/assets/i18n/en.json
+++ b/angular/file-explorer/src/assets/i18n/en.json
@@ -18,7 +18,7 @@
 	"Toggle task panel": "Toggle task panel",
 	"Activate this folder": "Activate this folder",
 	"Select the drivers to enable": "Select the drivers to enable",
-	"Save": "Save",
+	"Ok": "Ok",
 	"Annotations": "Annotations",
 	"Enabled drivers": "Enabled drivers",
 	"last update:": "last update: {{date}}",

--- a/angular/file-explorer/src/assets/i18n/fr.json
+++ b/angular/file-explorer/src/assets/i18n/fr.json
@@ -18,7 +18,7 @@
 	"Toggle task panel": "Afficher/Masquer le panneau des tâches",
 	"Activate this folder": "Activer ce dossier",
 	"Select the drivers to enable": "Sélectionner les drivers à activer",
-	"Save": "Enregistrer",
+	"Ok": "Ok",
 	"Annotations": "Annotations",
 	"Enabled drivers": "Drivers activés",
 	"last update:": "mise à jour le : {{date}}",

--- a/angular/file-explorer/src/assets/i18n/template.json
+++ b/angular/file-explorer/src/assets/i18n/template.json
@@ -18,7 +18,7 @@
 	"Toggle task panel": "Toggle task panel",
 	"Activate this folder": "Activate this folder",
 	"Select the drivers to enable": "Select the drivers to enable",
-	"Save": "Save",
+	"Ok": "Ok",
 	"Annotations": "Annotations",
 	"Enabled drivers": "Enabled drivers",
 	"last update:": "last update:",


### PR DESCRIPTION
**Before:**
- famwui can not start correctly because the env variable are not replaced
- button Save in famwui driver selection is misleading
- icon for driver selection can be improved
- default driver list is empty

**After:**
- famwui start with correct env variable changed in configuration
- `Save` is now `Ok`
- changed icon to `extension`
- default list is all drivers
