### PR TITLE
add secondary id

### DIFF
--- a/python/aias_common/access/storages/abstract.py
+++ b/python/aias_common/access/storages/abstract.py
@@ -35,7 +35,6 @@ class AbstractStorage(ABC):
             href = args[index]
             if self.is_path_authorized(href, action):
                 return fct(*args, **kwargs)
-            LOGGER.error("{} on {} is not permitted on {}".format(action.value, self.to_string(), href))
             raise PermissionError("{} access on {} is not permitted on {}".format(action.value, href, self.to_string()))
         return wrapper
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/ast_dem.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/ast_dem.py
@@ -120,6 +120,12 @@ class Driver(IngestDriver):
         return item
 
     def add_major_metadata(self, url: str, item: Item, metadata: dict) -> Item:
+        item.properties.secondary_id = (
+            metadata.get("INVENTORYMETADATA", {})
+            .get("ECSDATAGRANULE", {})
+            .get("LOCALGRANULEID", {})
+            .get("VALUE", None))
+
         item.properties.processing__level = (
             metadata.get("INVENTORYMETADATA", {})
             .get("COLLECTIONDESCRIPTIONCLASS", {})

--- a/python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py
@@ -132,6 +132,7 @@ class Driver(IngestDriver):
             if tile_md.get("rowGSD", None) and tile_md.get("columnGSD", None):
                 item.properties.gsd = sqrt(tile_md["rowGSD"]**2 + tile_md["columnGSD"]**2)
 
+            item.properties.secondary_id = self.tif_path.removesuffix(".tif")
             item.properties.satellite = metadata.get("EOMetadata", {}).get("satelliteName", None)
             item.properties.instrument = item.properties.satellite
             item.properties.sensor = item.properties.satellite

--- a/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
@@ -96,6 +96,7 @@ class Driver(IngestDriver):
         item.properties.satellite = item.properties.constellation
         item.properties.gsd = metadata.get("gsd", None)
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tif_path))
+        item.properties.secondary_id = metadata.get("id", None)
 
         return item
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/cosmoskymed.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/cosmoskymed.py
@@ -155,8 +155,8 @@ class Driver(IngestDriver):
         gsd = metadata.get("", {}).get("Ground_Range_Geometric_Resolution", None)
         if gsd is not None:
             item.properties.gsd = float(gsd)
-
         item.properties.satellite = metadata.get("", {}).get("Satellite_ID", None)
+        item.properties.secondary_id = metadata.get("", {}).get("Product_Filename", None)
 
         with AccessManager.make_local(self.h5met_path) as local_h5met_path:
             h5_tree = ET.parse(local_h5met_path)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/digitalglobe.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/digitalglobe.py
@@ -147,7 +147,7 @@ class Driver(IngestDriver):
         item.properties.gsd = find_or_none(metadata, "./IMD/IMAGE/MEANCOLLECTEDGSD", lambda x: float(x))
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tif_path))
         item.properties.satellite = find_or_none(metadata, "./IMD/IMAGE/SATID")
-
+        item.properties.secondary_id = find_or_none(metadata, "./IMD/PRODUCTORDERID")
         return item
 
     def add_minor_metadata(self, url: str, item: Item, metadata: ET.Element) -> Item:

--- a/python/extensions/aproc/proc/ingest/drivers/impl/dimap.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/dimap.py
@@ -205,10 +205,10 @@ class Driver(IngestDriver):
         # We calculate the GSD as the mean of GSD_ACROSS_TRACK and  GSD_ALONG_TRACK
         if "GSD_ACROSS_TRACK" in metadata and "GSD_ALONG_TRACK" in metadata:
             item.properties.gsd = (float(metadata["GSD_ACROSS_TRACK"]) + float(metadata["GSD_ALONG_TRACK"])) / 2
-
+        
         item.properties.processing__level = find_or_none(root, "PROCESSING_LEVEL")
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.dim_path))
-
+        item.properties.secondary_id = root.find("Dataset_Identification/DATASET_NAME").text
         return item
 
     def add_minor_metadata(self, url: str, item: Item, root: ET.Element) -> Item:

--- a/python/extensions/aproc/proc/ingest/drivers/impl/geoeye.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/geoeye.py
@@ -168,6 +168,7 @@ class Driver(IngestDriver):
             y_pixel_size = float(metadata['Pixel Size Y'].split(' ')[0])
             item.properties.gsd = (x_pixel_size + y_pixel_size) / 2
 
+        item.properties.secondary_id = self.tif_path.removesuffix(".tif")   # If merging files in one product: metadata.get("Product Order Number", None)
         item.properties.processing__level = metadata.get("Processing Level", None)
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tif_path))
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/geosat.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/geosat.py
@@ -118,6 +118,7 @@ class Driver(IngestDriver):
     def add_major_metadata(self, url: str, item: Item, root: ET.Element) -> Item:
         item.properties.proj__epsg = get_epsg_from_gdal_info(self.tif_path)
         item.properties.gsd = find_or_none(root, "./Dataset_Sources/Source_Information/Scene_Source/THEORETICAL_RESOLUTION", lambda x: float(x), Driver.ns)
+        item.properties.secondary_id = self.tif_path.removesuffix(".tif")
         return item
 
     def add_minor_metadata(self, url: str, item: Item, root: ET.Element) -> Item:

--- a/python/extensions/aproc/proc/ingest/drivers/impl/iceye.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/iceye.py
@@ -105,7 +105,7 @@ class Driver(IngestDriver):
     def add_major_metadata(self, url: str, item: Item, root: ET.Element) -> Item:
         item.properties.satellite = find_or_none(root, "satellite_name")
         item.properties.processing__level = find_or_none(root, "product_level")
-
+        item.properties.secondary_id = find_or_none(root, "product_name")
         range_spacing = find_or_none(root, "range_spacing", lambda x: float(x))
         azimuth_spacing = find_or_none(root, "azimuth_spacing", lambda x: float(x))
         if range_spacing and azimuth_spacing:

--- a/python/extensions/aproc/proc/ingest/drivers/impl/jpeg2000.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/jpeg2000.py
@@ -6,6 +6,7 @@ from extensions.aproc.proc.ingest.drivers.impl.image_driver_helper import \
 from extensions.aproc.proc.ingest.drivers.impl.utils import (downsample_image,
                                                              geotiff_to_jpg)
 from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
+import os
 
 
 class Driver(IngestDriver):
@@ -48,6 +49,7 @@ class Driver(IngestDriver):
         return ImageDriverHelper.build_core_item(self, url, ItemFormat.jpeg2000, AssetFormat.jpg2000, assets, metadata)
 
     def add_major_metadata(self, url: str, item: Item, metadata: object) -> Item:
+        item.properties.secondary_id = os.path.basename(url)
         return item
 
     def add_minor_metadata(self, url: str, item: Item, metadata: object) -> Item:

--- a/python/extensions/aproc/proc/ingest/drivers/impl/radarsat_2.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/radarsat_2.py
@@ -140,6 +140,7 @@ class Driver(IngestDriver):
     def add_major_metadata(self, url: str, item: Item, root: ET.Element) -> Item:
         item.properties.satellite = item.properties.constellation
         item.properties.processing__level = find_or_none(root, ".//rs2:productType", ns=Driver.ns)
+        item.properties.secondary_id = find_or_none(root, ".//rs2:productId", ns=Driver.ns)
 
         item.properties.proj__epsg = get_epsg_from_gdal_info(self.polarizations[0]['path'])
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/rapideye.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/rapideye.py
@@ -111,6 +111,7 @@ class Driver(IngestDriver):
     def add_major_metadata(self, url: str, item: Item, root: ET.Element) -> Item:
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tif_path))
         item.properties.processing__level = find_or_none(root, "gml:metaDataProperty/re:EarthObservationMetaData/eop:productType", ns=Driver.ns)
+        item.properties.secondary_id = find_or_none(root, "gml:metaDataProperty/re:EarthObservationMetaData/eop:identifier", ns=Driver.ns)
 
         gsd_col = find_or_none(root, "gml:resultOf/re:EarthObservationResult/eop:product/re:ProductInformation/re:columnGsd", lambda x: float(x), ns=Driver.ns)
         gsd_row = find_or_none(root, "gml:resultOf/re:EarthObservationResult/eop:product/re:ProductInformation/re:rowGsd", lambda x: float(x), ns=Driver.ns)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/sentinel_1.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/sentinel_1.py
@@ -205,6 +205,7 @@ class Driver(IngestDriver):
 
     def add_major_metadata(self, url: str, item: Item, root: ET.Element) -> Item:
         satellite_number = find_or_none(root, ".//safe:platform/safe:number", ns=Driver.ns)
+        item.properties.secondary_id = self.main_asset_path.removesuffix(".tiff")
         if satellite_number:
             item.properties.satellite = item.properties.constellation + satellite_number
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/sentinel_2.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/sentinel_2.py
@@ -132,7 +132,7 @@ class Driver(IngestDriver):
         for p_info in root.iter('Product_Info'):
             item.properties.processing__level = find_or_none(p_info, 'PROCESSING_LEVEL')
             item.properties.satellite = find_or_none(p_info, 'Datatake/SPACECRAFT_NAME')
-
+            item.properties.secondary_id = find_or_none(p_info, "PRODUCT_URI")
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tci_path))
 
         resolutions: list[float] = []

--- a/python/extensions/aproc/proc/ingest/drivers/impl/skysat.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/skysat.py
@@ -117,7 +117,7 @@ class Driver(IngestDriver):
     def add_major_metadata(self, url: str, item: Item, metadata: dict) -> Item:
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.sr_path))
         item.properties.gsd = metadata.get("properties", {}).get("gsd", None)
-
+        item.properties.secondary_id = metadata.get("id", None)
         item.properties.satellite = metadata.get("properties", {}).get("satellite_id", None)
 
         return item

--- a/python/extensions/aproc/proc/ingest/drivers/impl/spot5.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/spot5.py
@@ -129,7 +129,7 @@ class Driver(IngestDriver):
 
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.dim_path))
         item.properties.processing__level = metadata.get("PROCESSING_LEVEL", None)
-
+        item.properties.secondary_id = root.find('./Dataset_Sources/Source_Information/SOURCE_ID', Driver.ns).text
         return item
 
     def add_minor_metadata(self, url: str, item: Item, root: ET.Element) -> Item:

--- a/python/extensions/aproc/proc/ingest/drivers/impl/terrasarx.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/terrasarx.py
@@ -120,7 +120,7 @@ class Driver(IngestDriver):
             x_pixel_size = find_or_none(root, "productInfo/imageDataInfo/imageRaster/columnSpacing", lambda x: float(x))
             y_pixel_size = find_or_none(root, "productInfo/imageDataInfo/imageRaster/rowSpacing", lambda x: float(x))
         item.properties.gsd = (x_pixel_size + y_pixel_size) / 2
-
+        item.properties.secondary_id = find_or_none(root, "productComponents/annotation/file/location/filename")
         item.properties.processing__level = find_or_none(root, "setup/orderInfo/orderType")
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tif_path))
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/tiff.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/tiff.py
@@ -6,6 +6,7 @@ from extensions.aproc.proc.ingest.drivers.impl.image_driver_helper import \
 from extensions.aproc.proc.ingest.drivers.impl.utils import (downsample_image,
                                                              geotiff_to_jpg)
 from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
+import os
 
 
 class Driver(IngestDriver):
@@ -48,6 +49,7 @@ class Driver(IngestDriver):
         return ImageDriverHelper.build_core_item(self, url, ItemFormat.geotiff, AssetFormat.geotiff, assets, metadata)
 
     def add_major_metadata(self, url: str, item: Item, metadata: object) -> Item:
+        item.properties.secondary_id = os.path.basename(url)
         return item
 
     def add_minor_metadata(self, url: str, item: Item, metadata: object) -> Item:

--- a/python/extensions/aproc/proc/ingest/drivers/impl/umbra.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/umbra.py
@@ -98,6 +98,7 @@ class Driver(IngestDriver):
         return item
 
     def add_major_metadata(self, url: str, item: Item, metadata: dict) -> Item:
+        item.properties.secondary_id = metadata.get("collects", [{}])[0].get("id", None)
         item.properties.satellite = metadata.get("umbraSatelliteName", None)
         item.properties.gsd = metadata.get("baseIpr", None)
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tif_path))

--- a/python/extensions/aproc/proc/ingest/drivers/impl/wyvern.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/wyvern.py
@@ -188,6 +188,7 @@ class Driver(IngestDriver):
         item.properties.processing__level=processing__level
         item.properties.proj__epsg=proj__epsg
         item.properties.satellite=satellite
+        item.properties.secondary_id = metadata.get("id", None)
         return item
 
     def add_minor_metadata(self, url: str, item: Item, metadata: dict) -> Item:

--- a/python/extensions/aproc/proc/ingest/drivers/ingest_driver.py
+++ b/python/extensions/aproc/proc/ingest/drivers/ingest_driver.py
@@ -208,6 +208,8 @@ class IngestDriver(AbstractDriver):
             url (str): archive's url
             item (Item): the item
         """
+        if item.properties.secondary_id is None:
+            self.LOGGER.warn(f"No ID was found for {url}")
         if item.properties.satellite is None:
             self.LOGGER.warn(f"No satellite was found for {url}")
         if item.properties.gsd is None:

--- a/test/aproc_ingest_tests.py
+++ b/test/aproc_ingest_tests.py
@@ -150,6 +150,7 @@ class IngestTests(unittest.TestCase):
             self.assertTrue(item.assets.get(Role.overview.value).airs__managed, f"overview asset should be managed for {id}")
         self.assertIsNotNone(item.properties.datetime, asset)
         if archive:
+            self.assertIsNotNone(item.properties.secondary_id)
             self.assertIsNotNone(item.properties.constellation)
             self.assertIsNotNone(item.properties.instrument)
             self.assertIsNotNone(item.properties.sensor)


### PR DESCRIPTION
Before:
- archives usually have an id but it is not in the item

After:
- archive id from the provider is added as a secondary id in the item

fix #391 