### PR TITLE
fix bsg G3 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -136,6 +136,9 @@ jobs:
         pip install -r test/requirements.tests.txt
     - name: Start stack
       run: test/start_stack.sh
+    - name: Logs dockers aproc-service
+      run: test/logs.sh arlas-server
+      if: always()
     - name: Run g2 tests
       run: test/tests_g2.sh
     - name: Logs dockers aproc-service

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/inputs/DIMAP
 test/inputs/theia
 test/inputs/many
 test/inputs/SPOT5-2.5M
+test/inputs/proprietary
 out/
 airs.egg-info/
 .env

--- a/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
@@ -122,14 +122,14 @@ class Driver(IngestDriver):
         self.__init__()
         if AccessManager.is_dir(path):
             for f in AccessManager.listdir(path):
-                if not f.is_dir:
-                    if f.name.lower().startswith("bsg-") and f.path.lower().endswith(".tif") and not f.path.lower().endswith("pan.tif"):
+                if not f.is_dir and f.name.lower().startswith("bsg-"):
+                    if f.path.lower().endswith(".tif") and not f.path.lower().endswith("pan.tif"):
                         self.tif_path = f.path
-                    elif f.name.lower().startswith("bsg-") and f.path.lower().endswith("pan.tif"):
+                    elif f.path.lower().endswith("pan.tif"):
                         self.pan_tif_path = f.path
-                    elif f.name.lower().startswith("bsg-") and f.path.endswith(".json"):
+                    elif f.path.endswith(".json"):
                         self.md_path = f.path
-                    elif f.name.lower().startswith("bsg-") and f.path.endswith("browse.png"):
+                    elif f.path.endswith("browse.png"):
                         self.quicklook_path = f.path
             return self.tif_path is not None and self.pan_tif_path is not None and self.md_path is not None
         return False

--- a/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
@@ -102,7 +102,7 @@ class Driver(IngestDriver):
 
     def add_major_metadata(self, url: str, item: Item, metadata: dict) -> Item:
         item.properties.satellite = item.properties.constellation
-        item.properties.gsd = metadata.get("gsd", None)
+        item.properties.gsd = metadata.get("gsd", metadata.get("sensors", {}).get("rgb", {}).get("properties", {}).get("gsd", None))
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tif_path))
         item.properties.secondary_id = metadata.get("id", None)
         item.properties.processing__level= metadata.get("processingLevel", None)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
@@ -13,6 +13,7 @@ from extensions.aproc.proc.ingest.drivers.impl.utils import (downsample_image,
                                                              get_centroid,
                                                              get_epsg)
 from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
+from dateutil import parser
 
 
 class Driver(IngestDriver):
@@ -72,12 +73,14 @@ class Driver(IngestDriver):
         return md
 
     def build_core_item(self, url: str, assets: list[Asset], metadata: dict) -> Item:
-        geometry = metadata["geometry"]
+        if metadata.get("geometry", None) is None and metadata.get("sensors", {}).get("rgb"):
+            geometry = metadata["sensors"]["rgb"]["geometry"]            
+        else:
+            geometry = metadata["geometry"]
         centroid = get_centroid(geometry)
         bbox = get_bbox(geometry["coordinates"][0])
 
-        date = datetime.strptime(metadata["acquisitionDate"], "%Y-%m-%dT%H:%M:%S.%f")
-
+        date = parser.parse(metadata["acquisitionDate"])
         item = Item(
             geometry=geometry,
             bbox=bbox,
@@ -102,7 +105,7 @@ class Driver(IngestDriver):
         item.properties.gsd = metadata.get("gsd", None)
         item.properties.proj__epsg = get_epsg(AccessManager.get_gdal_proj(self.tif_path))
         item.properties.secondary_id = metadata.get("id", None)
-
+        item.properties.processing__level= metadata.get("processingLevel", None)
         return item
 
     def add_minor_metadata(self, url: str, item: Item, metadata: dict) -> Item:
@@ -112,7 +115,7 @@ class Driver(IngestDriver):
         item.properties.view__off_nadir = metadata.get("offNadirAngle", None)
         item.properties.view__sun_azimuth = metadata.get("sunAzimuth", None)
         item.properties.view__sun_elevation = metadata.get("sunElevation", None)
-
+        item.properties.eo__cloud_cover= metadata.get("cloudCoverPercent", metadata.get("sensors", {}).get("rgb", {}).get("properties", {}).get("cloudCoverPercent", None))
         return item
 
     def __check_path__(self, path: str):
@@ -120,13 +123,13 @@ class Driver(IngestDriver):
         if AccessManager.is_dir(path):
             for f in AccessManager.listdir(path):
                 if not f.is_dir:
-                    if f.path.lower().endswith("ortho.tif"):
+                    if f.name.lower().startswith("bsg-") and f.path.lower().endswith(".tif") and not f.path.lower().endswith("pan.tif"):
                         self.tif_path = f.path
-                    elif f.path.lower().endswith("ortho-pan.tif"):
+                    elif f.name.lower().startswith("bsg-") and f.path.lower().endswith("pan.tif"):
                         self.pan_tif_path = f.path
-                    elif f.path.endswith("_metadata.json"):
+                    elif f.name.lower().startswith("bsg-") and f.path.endswith(".json"):
                         self.md_path = f.path
-                    elif f.path.endswith("_browse.png"):
+                    elif f.name.lower().startswith("bsg-") and f.path.endswith("browse.png"):
                         self.quicklook_path = f.path
             return self.tif_path is not None and self.pan_tif_path is not None and self.md_path is not None
         return False


### PR DESCRIPTION
Fix #414 

**Before:**
- BSG G3 not recognized
- cloud cover not identified
- processing level not identified
- geometry not identified in G3

**After:**
- BSG recognized if the files start with `BSG-` and ends with expected suffixes
- cloud cover identified
- geometry identified in G3
- processing level identified in G3
- Flexible date parsing

Two metadata structures supported:
Initial one:
```json
{
  "id" : "BSG-XXXXXXXXXXXXXXXXx",
  "acquisitionDate" : "20XX-XXXXXXXXXX",
  "sensorName" : "Global-8",
  "gsd" : 0.9,
  "geometry" : {
    "type" : "Polygon",
    "coordinates" : [ [ ... ] ] ]
  },
  "cloudCoverPercent" : 0.0,
  "offNadirAngle" : 12,
  "sunElevation" : 16,
  "sunAzimuth" : 156,
  "satelliteElevation" : 61,
  "satelliteAzimuth" : 202,
  ...
}
```

New one:
```json
{
  "metadataFileVersion" : "2.0-COMMERCIAL",
  "properties" : {
    "offNadirAngle" : 15,
    "satelliteAzimuth" : 22,
    "satelliteElevation" : 66,
    "sunAzimuth" : 121,
    "sunElevation" : 12
  },
  "sensors" : {
    "rgb" : {
      "geometry" : {
        "type" : "Polygon",
        "coordinates" : [ [ [ ... ] ] ]
      },
      "properties" : {
        "cloudCoverPercent" : 0.0,
        "gsd" : 0.3,
      }
    },
    "pan" : {
       ...
    }
  },
  "systemData" : {
    "requestId" : "xxxxxx",
    "captureId" : "xxxxx",
    "productId" : "xxxxxxx"
  },
  "id" : "BSG-xxxxxxxxxxxxxxxxxxxxxx",
  "acquisitionDate" : "202xxxxxxxxxxxxxxxxxxxxx",
  "productType" : "STANDARD",
  "satelliteType" : "gen3",
  "sensorName" : "Global-33",
  "processingLevel" : "L3"
}
```