### PR TITLE
add stretch and remote as conf for building overviews

### DIFF
--- a/python/extensions/aproc/proc/ingest/drivers/impl/ast_dem.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/ast_dem.py
@@ -25,16 +25,20 @@ class Driver(IngestDriver):
         "LOWERLEFTCORNERLONGITUDE": "WESTBOUNDINGCOORDINATE",
     }
 
+    configuration: dict = {}
+
+    # Implements drivers method
+    @staticmethod
+    def init(configuration: dict):
+        IngestDriver.init(configuration)
+        Driver.configuration = configuration
+
     def __init__(self):
         super().__init__()
         self.met_path = None
         self.tif_path = None
         self.tfw_path = None
 
-    # Implements drivers method
-    @staticmethod
-    def init(configuration: dict):
-        IngestDriver.init(configuration)
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -54,9 +58,9 @@ class Driver(IngestDriver):
 
     # Implements drivers method
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
-        if AccessManager.is_local(self.tif_path):
+        if AccessManager.is_local(self.tif_path) and Driver.configuration.get('build_overview_when_local', True):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href)
+            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             assets.append(quicklook)
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py
@@ -19,6 +19,9 @@ from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
 
 
 class Driver(IngestDriver):
+
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
 
@@ -30,6 +33,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -60,9 +64,9 @@ class Driver(IngestDriver):
 
     # Implements drivers method
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
-        if AccessManager.is_local(self.tif_path):
+        if AccessManager.is_local(self.tif_path) and Driver.configuration.get('build_overview_when_local', True):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href, bands_list=[1, 2, 3])
+            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href, bands_list=[1, 2, 3], stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             assets.append(quicklook)
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/bsg.py
@@ -16,6 +16,8 @@ from dateutil import parser
 
 
 class Driver(IngestDriver):
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.tif_path = None
@@ -23,9 +25,11 @@ class Driver(IngestDriver):
         self.md_path = None
         self.quicklook_path = None
 
+    # Implements drivers method
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     def identify_assets(self, url: str):
         assets: list[Asset] = []
@@ -46,7 +50,7 @@ class Driver(IngestDriver):
         return assets
 
     def transform_assets(self, url: str, assets: list[Asset]):
-        if self.quicklook_path is None and AccessManager.is_local(self.tif_path):
+        if self.quicklook_path is None and AccessManager.is_local(self.tif_path) and Driver.configuration.get('build_overview_when_local', True):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
             geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href, stretch=True)
             quicklook.size = AccessManager.get_size(quicklook.href)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/cosmoskymed.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/cosmoskymed.py
@@ -17,6 +17,8 @@ from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
 
 class Driver(IngestDriver):
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.data_path = None
@@ -35,6 +37,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -77,7 +80,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if self.browse_path is not None:
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.browse_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href)
+            geotiff_to_jpg(self.browse_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             assets.append(quicklook)
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/digitalglobe.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/digitalglobe.py
@@ -16,6 +16,8 @@ from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
 
 class Driver(IngestDriver):
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.quicklook_path = None
@@ -29,6 +31,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -66,7 +69,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if self.quicklook_path is None and AccessManager.is_local(self.tif_path):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href)
+            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             self.quicklook_path = quicklook.href
             assets.append(quicklook)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/dimap.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/dimap.py
@@ -16,6 +16,8 @@ from airs.core.models.model import SensorType
 
 class Driver(IngestDriver):
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.quicklook_path = None
@@ -29,6 +31,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -84,7 +87,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if self.quicklook_path is None and AccessManager.is_local(self.image_path):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.image_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href)
+            geotiff_to_jpg(self.image_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             self.quicklook_path = quicklook.href
             assets.append(quicklook)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/geoeye.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/geoeye.py
@@ -16,6 +16,8 @@ from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
 
 class Driver(IngestDriver):
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.quicklook_path = None
@@ -29,6 +31,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -60,7 +63,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if self.quicklook_path is None and AccessManager.is_local(self.tif_path):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href)
+            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             self.quicklook_path = quicklook.href
             assets.append(quicklook)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/geosat.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/geosat.py
@@ -20,6 +20,8 @@ from dateutil import parser
 class Driver(IngestDriver):
     ns = {"xsi": "http://www.w3.org/2001/XMLSchema-instance"}  # NOSONAR
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.thumbnail_path = None
@@ -31,6 +33,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -60,7 +63,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if self.quicklook_path is None and AccessManager.is_local(self.tif_path):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href, bands_list=[1, 2, 3])
+            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href, bands_list=[1, 2, 3], stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             self.quicklook_path = quicklook.href
             assets.append(quicklook)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/jpeg2000.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/jpeg2000.py
@@ -11,6 +11,8 @@ import os
 
 class Driver(IngestDriver):
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
 
@@ -18,6 +20,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -32,7 +35,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if AccessManager.is_local(url):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(url, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=True)
+            geotiff_to_jpg(url, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=Driver.configuration.get('overview_stretch', True))
             quicklook.size = AccessManager.get_size(quicklook.href)
             assets.append(quicklook)
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/radarsat_2.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/radarsat_2.py
@@ -16,6 +16,8 @@ from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
 class Driver(IngestDriver):
     ns = {"rs2": "http://www.rsi.ca/rs2/prod/xml/schemas"}  # NOSONAR
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.md_path = None
@@ -37,6 +39,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -70,7 +73,7 @@ class Driver(IngestDriver):
 
         if image_path:
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(image_path, quicklook_pct, quicklook_pct, output_path=quicklook.href)
+            geotiff_to_jpg(image_path, quicklook_pct, quicklook_pct, output_path=quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             assets.append(quicklook)
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/rapideye.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/rapideye.py
@@ -19,6 +19,8 @@ class Driver(IngestDriver):
           "re": "http://schemas.rapideye.de/products/productMetadataGeocorrected",
           "eop": "http://earth.esa.int/eop",
           "opt": "http://earth.esa.int/opt"}
+    
+    configuration: dict = {}
 
     def __init__(self):
         super().__init__()
@@ -31,6 +33,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -60,7 +63,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if self.browse_path:
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.browse_path, Driver.OVERVIEW_FROM_BROWSE_PCT, Driver.OVERVIEW_FROM_BROWSE_PCT, output_path=quicklook.href)
+            geotiff_to_jpg(self.browse_path, Driver.OVERVIEW_FROM_BROWSE_PCT, Driver.OVERVIEW_FROM_BROWSE_PCT, output_path=quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             assets.append(quicklook)
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/satellogic.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/satellogic.py
@@ -30,6 +30,8 @@ class Driver(IngestDriver):
     - Preview PNG (*_preview.png) - optional
     """
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.md_path = None
@@ -44,6 +46,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -170,7 +173,7 @@ class Driver(IngestDriver):
                 Driver.OVERVIEW_FROM_LARGE_TIFF_PCT,
                 output_path=quicklook.href,
                 bands_list=bands,
-                stretch=not self.visual_path
+                stretch=False if self.visual_path else Driver.configuration.get('overview_stretch', True)
             )
             quicklook.size = AccessManager.get_size(quicklook.href)
             assets.append(quicklook)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/sentinel_2.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/sentinel_2.py
@@ -81,7 +81,7 @@ class Driver(IngestDriver):
         if AccessManager.is_local(self.tci_path) and Driver.configuration.get('build_overview_when_local', True):
             Driver.LOGGER.debug(f"Building overview for local TCI {self.tci_path}")
             overview = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.tci_path, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, overview.href, [1, 2, 3])
+            geotiff_to_jpg(self.tci_path, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, overview.href, [1, 2, 3], stretch=Driver.configuration.get('overview_stretch', False))
             overview.size = AccessManager.get_size(overview.href)
             assets.append(overview)
         elif Driver.configuration and Driver.configuration.get('build_overview_when_remote', False):
@@ -92,7 +92,7 @@ class Driver(IngestDriver):
             # File is processed locally as it significantly speeds up processing time
             with AccessManager.make_local(self.tci_path) as local_tci_path:
                 overview = ImageDriverHelper.prepare_preview_asset(self, overview_path, Role.overview, MimeType.JPG, AssetFormat.jpg)
-                geotiff_to_jpg(local_tci_path, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, overview.href, [1, 2, 3])
+                geotiff_to_jpg(local_tci_path, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, overview.href, [1, 2, 3], stretch=Driver.configuration.get('overview_stretch', False))
                 overview.size = AccessManager.get_size(overview.href)
                 assets.append(overview)
         else:

--- a/python/extensions/aproc/proc/ingest/drivers/impl/skysat.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/skysat.py
@@ -13,6 +13,9 @@ from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
 
 
 class Driver(IngestDriver):
+
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.md_path = None
@@ -26,6 +29,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -64,7 +68,7 @@ class Driver(IngestDriver):
         else:
             bands = [3, 2, 1]
             tif_path = self.sr_path
-            stretch = True
+            stretch = Driver.configuration.get('overview_stretch', True)
 
         # Skip generation if tif is not local
         if not AccessManager.is_local(tif_path):

--- a/python/extensions/aproc/proc/ingest/drivers/impl/spot5.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/spot5.py
@@ -16,6 +16,7 @@ from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
 
 class Driver(IngestDriver):
     ns = {"xsi": "http://www.w3.org/2001/XMLSchema-instance"}  # NOSONAR
+    configuration: dict = {}
 
     def __init__(self):
         super().__init__()
@@ -29,6 +30,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -65,7 +67,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if self.quicklook_path is None and AccessManager.is_local(self.tif_path):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href)
+            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             self.quicklook_path = quicklook.href
             assets.append(quicklook)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/terrasarx.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/terrasarx.py
@@ -16,6 +16,8 @@ from airs.core.models.model import SensorType
 
 class Driver(IngestDriver):
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.browse_path = None
@@ -27,6 +29,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -53,7 +56,7 @@ class Driver(IngestDriver):
     # Implements drivers method
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-        geotiff_to_jpg(self.browse_path, Driver.OVERVIEW_FROM_BROWSE_PCT, Driver.OVERVIEW_FROM_BROWSE_PCT, quicklook.href)
+        geotiff_to_jpg(self.browse_path, Driver.OVERVIEW_FROM_BROWSE_PCT, Driver.OVERVIEW_FROM_BROWSE_PCT, quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
         quicklook.size = AccessManager.get_size(quicklook.href)
         assets.append(quicklook)
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/tiff.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/tiff.py
@@ -11,6 +11,8 @@ import os
 
 class Driver(IngestDriver):
 
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
 
@@ -18,6 +20,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     # Implements drivers method
     def identify_assets(self, url: str) -> list[Asset]:
@@ -32,7 +35,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if AccessManager.is_local(url):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(url, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=True)
+            geotiff_to_jpg(url, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, quicklook.href, stretch=Driver.configuration.get('overview_stretch', True))
             quicklook.size = AccessManager.get_size(quicklook.href)
             assets.append(quicklook)
 

--- a/python/extensions/aproc/proc/ingest/drivers/impl/umbra.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/umbra.py
@@ -14,6 +14,9 @@ from extensions.aproc.proc.ingest.drivers.ingest_driver import IngestDriver
 
 
 class Driver(IngestDriver):
+
+    configuration: dict = {}
+
     def __init__(self):
         super().__init__()
         self.tif_path = None
@@ -23,6 +26,7 @@ class Driver(IngestDriver):
     @staticmethod
     def init(configuration: dict):
         IngestDriver.init(configuration)
+        Driver.configuration = configuration
 
     def identify_assets(self, url: str):
         assets: list[Asset] = []
@@ -45,7 +49,7 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]):
         if self.quicklook_path is None and AccessManager.is_local(self.tif_path):
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href)
+            geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT, Driver.OVERVIEW_FROM_TIFF_PCT, output_path=quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
             quicklook.size = AccessManager.get_size(quicklook.href)
             self.quicklook_path = quicklook.href
             assets.append(quicklook)

--- a/python/extensions/aproc/proc/ingest/drivers/impl/umbra_stac.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/umbra_stac.py
@@ -50,7 +50,7 @@ class Driver(IngestDriver):
             if AccessManager.is_local(self.tif_path) and Driver.configuration.get('build_overview_when_local', True):
                 Driver.LOGGER.debug(f"Building overview for local TIFF {self.tif_path}")
                 quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-                geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT/5, Driver.OVERVIEW_FROM_TIFF_PCT/5, output_path=quicklook.href)
+                geotiff_to_jpg(self.tif_path, Driver.OVERVIEW_FROM_TIFF_PCT/5, Driver.OVERVIEW_FROM_TIFF_PCT/5, output_path=quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
                 quicklook.size = AccessManager.get_size(quicklook.href)
                 self.quicklook_path = quicklook.href
                 assets.append(quicklook)
@@ -61,7 +61,7 @@ class Driver(IngestDriver):
                 overview_path = overview_folder + '/overview.jpg'
                 with AccessManager.make_local(self.tif_path) as local_tif_path:
                     quicklook = ImageDriverHelper.prepare_preview_asset(self, overview_path, Role.overview, MimeType.JPG, AssetFormat.jpg)
-                    geotiff_to_jpg(local_tif_path, Driver.OVERVIEW_FROM_TIFF_PCT/5, Driver.OVERVIEW_FROM_TIFF_PCT/5, output_path=quicklook.href)
+                    geotiff_to_jpg(local_tif_path, Driver.OVERVIEW_FROM_TIFF_PCT/5, Driver.OVERVIEW_FROM_TIFF_PCT/5, output_path=quicklook.href, stretch=Driver.configuration.get('overview_stretch', False))
                     quicklook.size = AccessManager.get_size(quicklook.href)
                     self.quicklook_path = quicklook.href
                     assets.append(quicklook)
@@ -113,7 +113,6 @@ class Driver(IngestDriver):
         end_datetime = parse_dt(end_dt_str)
 
         constellation = props.get("constellation", "UMBRA").upper()
-        satellite = props.get("platform", "UMBRA")
 
         item = Item(
             geometry=geometry,


### PR DESCRIPTION
For every driver that builds an overview, make configurable the generation, when local or when remote and the stretch.