### PR TITLE
Improve csk overview building and measure test durations

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,1 +1,2 @@
 CVE-2026-23231 # no fix yet on image
+CVE-2026-23112 # no fix yet on image

--- a/python/extensions/aproc/proc/ingest/drivers/impl/capella.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/capella.py
@@ -49,34 +49,45 @@ class Driver(IngestDriver):
         if self.big_preview_path:
             asset = ImageDriverHelper.add_asset(assets, self.big_preview_path, Role.overview, MimeType.TIFF, AssetFormat.geotiff, ResourceType.gridded)
             asset.name = "big_preview"
+
+        if self.quicklook_path:
+            ImageDriverHelper.add_asset(assets, self.quicklook_path, Role.overview, MimeType.PNG, AssetFormat.png, ResourceType.other, airs__managed=True)
+
         return assets
 
     def fetch_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
+        if self.quicklook_path:
+            quicklook = ImageDriverHelper.make_local_overview_asset(self, url, self.quicklook_path, MimeType.PNG, AssetFormat.png)
+            self.quicklook_path = quicklook.href
+            assets.append(quicklook)
         return assets
 
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
-        tif_for_overview = self.big_preview_path if self.big_preview_path else self.tif_path
-        if AccessManager.is_local(tif_for_overview) and Driver.configuration.get('build_overview_when_local', True):
-            Driver.LOGGER.debug(f"Building overview for local {tif_for_overview}")
-            overview = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
-            geotiff_to_jpg(tif_for_overview, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, overview.href, [1, 1, 1], Driver.configuration.get('overview_stretch', True))
-            overview.size = AccessManager.get_size(overview.href)
-            self.quicklook_path = overview.href
-            assets.append(overview)
-        elif Driver.configuration and Driver.configuration.get('build_overview_when_remote', False):
-            Driver.LOGGER.debug(f"Building overview for remote {tif_for_overview}")
-            overview_folder = self.assets_dir + '/capella/' + self.get_item_id(url) + '/overview'
-            AccessManager.makedir(overview_folder)
-            overview_path = overview_folder + '/overview.jpg'
-            # File is processed locally as it significantly speeds up processing time
-            with AccessManager.make_local(tif_for_overview) as local_big_preview_path:
-                overview = ImageDriverHelper.prepare_preview_asset(self, overview_path, Role.overview, MimeType.JPG, AssetFormat.jpg)
-                geotiff_to_jpg(local_big_preview_path, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, overview.href, [1, 1, 1], Driver.configuration.get('overview_stretch', True))
+        if self.quicklook_path is None:
+            tif_for_overview = self.big_preview_path if self.big_preview_path else self.tif_path
+            if AccessManager.is_local(tif_for_overview) and Driver.configuration.get('build_overview_when_local', True):
+                Driver.LOGGER.debug(f"Building overview for local {tif_for_overview}")
+                overview = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
+                geotiff_to_jpg(tif_for_overview, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, overview.href, [1, 1, 1], Driver.configuration.get('overview_stretch', True))
                 overview.size = AccessManager.get_size(overview.href)
                 self.quicklook_path = overview.href
                 assets.append(overview)
+            elif Driver.configuration and Driver.configuration.get('build_overview_when_remote', False):
+                Driver.LOGGER.debug(f"Building overview for remote {tif_for_overview}")
+                overview_folder = self.assets_dir + '/capella/' + self.get_item_id(url) + '/overview'
+                AccessManager.makedir(overview_folder)
+                overview_path = overview_folder + '/overview.jpg'
+                # File is processed locally as it significantly speeds up processing time
+                with AccessManager.make_local(tif_for_overview) as local_big_preview_path:
+                    overview = ImageDriverHelper.prepare_preview_asset(self, overview_path, Role.overview, MimeType.JPG, AssetFormat.jpg)
+                    geotiff_to_jpg(local_big_preview_path, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, Driver.OVERVIEW_FROM_LARGE_TIFF_PCT, overview.href, [1, 1, 1], Driver.configuration.get('overview_stretch', True))
+                    overview.size = AccessManager.get_size(overview.href)
+                    self.quicklook_path = overview.href
+                    assets.append(overview)
+            else:
+                Driver.LOGGER.debug("Skipping overview generation for TCI {}".format(self.big_preview_path))
         else:
-            Driver.LOGGER.debug("Skipping overview generation for TCI {}".format(self.big_preview_path))
+            Driver.LOGGER.debug("Overview exists {}".format(self.quicklook_path))
 
         if self.quicklook_path is not None:
             thumbnail_type = MimeType.JPG
@@ -194,6 +205,8 @@ class Driver(IngestDriver):
             for f in files:
                 filename = f.name.lower()
                 if not f.is_dir and filename.startswith("capella_"):
+                    if filename.endswith("_thumb.png"):
+                        self.quicklook_path = f.path
                     if filename.endswith("_preview.tif"):
                         self.big_preview_path = f.path
                     elif filename.endswith(".tif"):

--- a/python/extensions/aproc/proc/ingest/drivers/impl/cosmoskymed.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/cosmoskymed.py
@@ -95,7 +95,7 @@ class Driver(IngestDriver):
 
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
 
-            with AccessManager.stream(self.data_path) as f:
+            with AccessManager.make_local(self.data_path) as f:
                 with h5py.File(f) as h5f:
                     max_height = -np.inf
                     values = []

--- a/test/agate_tests.py
+++ b/test/agate_tests.py
@@ -1,21 +1,22 @@
 import json
 import os
 import unittest
+from test.aproc_tests import AprocTests
 from test.utils import (AGATE_ENDPOINT, AIRS_URL, ARLAS_COLLECTION, ARLAS_URL,
                         ASSET, ASSET_PATH, COLLECTION, ID, ITEM_PATH,
-                        index_collection_prefix, setUpTest)
+                        index_collection_prefix)
 from time import sleep
 from urllib import parse
-import requests
 
+import requests
 from airs.core.models import mapper
 from airs.core.models.model import Item
 
 
-class Tests(unittest.TestCase):
+class Tests(AprocTests):
 
     def setUp(self):
-        setUpTest()
+        super().setUp()
         try:
             requests.delete("/".join([ARLAS_URL, "arlas", "collections", ARLAS_COLLECTION]))
         except Exception:

--- a/test/airs_tests.py
+++ b/test/airs_tests.py
@@ -1,4 +1,5 @@
 import json
+from time import sleep
 import unittest
 from test.aproc_tests import AprocTests
 from test.utils import (AIRS_URL, ASSET, ASSET_PATH, COLLECTION, ID_MANAGED,
@@ -14,6 +15,12 @@ from airs.core.models.stacapi import CollectionDescriptionListResponse
 class Tests(AprocTests):
 
     def test_not_found(self):
+        # ITEM does not exist
+        r = requests.get(url="/".join([AIRS_URL, "collections", COLLECTION, "items"]), headers={"Content-Type": "application/json"})
+        self.assertFalse(r.ok, str(r.status_code) + str(r.content))
+        # ASSET does not exist
+        r = requests.head(url="/".join([AIRS_URL, "collections", COLLECTION, "items", ID_MANAGED, "assets", ASSET]))
+        self.assertFalse(r.ok, str(r.status_code) + str(r.content))
         # ADD ITEM FAIL BECAUSE ASSET MISSING
         with open(ITEM_PATH_MANAGED, 'r') as file:
             data = file.read()

--- a/test/airs_tests.py
+++ b/test/airs_tests.py
@@ -1,21 +1,17 @@
 import json
-import os
-from time import sleep
 import unittest
-from airs.core.models.stacapi import CollectionDescriptionListResponse
-from test.utils import (AIRS_URL, ASSET, ASSET_PATH, COLLECTION, ID_MANAGED, ITEM_PATH_MANAGED,
-                        index_collection_prefix, index_endpoint_url, setUpTest)
+from test.aproc_tests import AprocTests
+from test.utils import (AIRS_URL, ASSET, ASSET_PATH, COLLECTION, ID_MANAGED,
+                        ITEM_PATH_MANAGED, index_collection_prefix,
+                        index_endpoint_url)
 
 import elasticsearch
 import requests
-
 from airs.core.models import mapper as mapper
+from airs.core.models.stacapi import CollectionDescriptionListResponse
 
 
-class Tests(unittest.TestCase):
-
-    def setUp(self):
-        setUpTest()
+class Tests(AprocTests):
 
     def test_not_found(self):
         # ADD ITEM FAIL BECAUSE ASSET MISSING

--- a/test/aproc_dc3build_tests.py
+++ b/test/aproc_dc3build_tests.py
@@ -2,9 +2,10 @@ import datetime
 import json
 import time
 import unittest
+from test.aproc_tests import AprocTests
 from test.utils import (AIRS_URL, APROC_ENDPOINT, COLLECTION, MAX_ITERATIONS,
                         SENTINEL_2_ZIP_ID, SENTINEL_2_ZIP_ITEM, TOKEN, add_item,
-                        create_arlas_collection, setUpTest)
+                        create_arlas_collection)
 from time import sleep
 
 import requests
@@ -22,9 +23,7 @@ from extensions.aproc.proc.processes.arlas_services_helper import \
     ARLASServicesHelper
 
 
-class Tests(unittest.TestCase):
-    def setUp(self):
-        setUpTest()
+class Tests(AprocTests):
 
     def test_build_cube(self):
         item = self.ingest_sentinel()

--- a/test/aproc_download_tests.py
+++ b/test/aproc_download_tests.py
@@ -1,11 +1,11 @@
 import json
 import os
 import unittest
+from test.aproc_tests import AprocTests
 from test.utils import (APROC_ENDPOINT, ASSET_NAME, BBOX, CLOUD_ID, CLOUD_ITEM,
                         COLLECTION, EPSG_27572, ID, ITEM_PATH, MAX_ITERATIONS,
                         MINIO_ID, MINIO_ITEM, SENTINEL_2_ID, SENTINEL_2_ITEM, SENTINEL_2_ZIP_ID, SENTINEL_2_ZIP_ITEM,
-                        SMTP_SERVER, TOKEN, add_item, create_arlas_collection,
-                        setUpTest)
+                        SMTP_SERVER, TOKEN, add_item, create_arlas_collection)
 from time import sleep
 
 import requests
@@ -18,10 +18,10 @@ from extensions.aproc.proc.download.download_process import (
     InputDownloadProcess, OutputDownloadProcess)
 
 
-class Tests(unittest.TestCase):
+class Tests(AprocTests):
 
     def setUp(self):
-        setUpTest()
+        super().setUp()
         requests.delete(SMTP_SERVER + "/*")
         add_item(self, ITEM_PATH, ID)
         sleep(3)

--- a/test/aproc_enrich_tests.py
+++ b/test/aproc_enrich_tests.py
@@ -4,18 +4,16 @@ import unittest
 from airs.core.models import mapper
 from aproc.core.models.ogc.enums import StatusCode
 from aproc.core.models.ogc.job import StatusInfo
+from test.aproc_tests import AprocTests
 from test.utils import (AIRS_URL, APROC_ENDPOINT, COLLECTION, SENTINEL_2_ID, SENTINEL_2_ITEM, SENTINEL_2_ZIP_ID, MAX_ITERATIONS,
-                        SENTINEL_2_ZIP_ITEM, setUpTest, add_item)
-
+                        SENTINEL_2_ZIP_ITEM, add_item)
 import requests
 
 from aproc.core.models.ogc import Execute
 from extensions.aproc.proc.enrich.enrich_process import InputEnrichProcess
 
 
-class Tests(unittest.TestCase):
-    def setUp(self):
-        setUpTest()
+class Tests(AprocTests):
 
     def __enrich_cog(self, id: str, item: str):
         add_item(self, item, id)

--- a/test/aproc_ingest_tests.py
+++ b/test/aproc_ingest_tests.py
@@ -1,14 +1,12 @@
-from datetime import datetime
 import json
 import threading
 import unittest
-from time import sleep
 from test.aproc_tests import AprocTests
+from test.utils import APROC_ENDPOINT, CATALOG, COLLECTION, MAX_ITERATIONS
+from time import sleep
 
 import requests
 import uvicorn
-from fastapi import FastAPI, Request
-
 from airs.core.models import mapper
 from airs.core.models.model import Item, Role
 from aproc.core.models.ogc import Execute
@@ -18,7 +16,7 @@ from aproc.core.models.ogc.process import ProcessDescription, ProcessList
 from extensions.aproc.proc.ingest.directory_ingest_process import \
     InputDirectoryIngestProcess
 from extensions.aproc.proc.ingest.ingest_process import InputIngestProcess
-from test.utils import (APROC_ENDPOINT, CATALOG, COLLECTION, MAX_ITERATIONS)
+from fastapi import FastAPI, Request
 
 AST = "ast/"
 CSK = "csk/3155919-2167789/CSKS4_SCS_B_WR_03_VV_RA_SF_20141001061215_20141001061230.h5"

--- a/test/aproc_ingest_tests.py
+++ b/test/aproc_ingest_tests.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 import json
 import threading
 import unittest
 from time import sleep
+from test.aproc_tests import AprocTests
 
 import requests
 import uvicorn
@@ -16,8 +18,7 @@ from aproc.core.models.ogc.process import ProcessDescription, ProcessList
 from extensions.aproc.proc.ingest.directory_ingest_process import \
     InputDirectoryIngestProcess
 from extensions.aproc.proc.ingest.ingest_process import InputIngestProcess
-from test.utils import (APROC_ENDPOINT, CATALOG, COLLECTION, MAX_ITERATIONS,
-                        setUpTest)
+from test.utils import (APROC_ENDPOINT, CATALOG, COLLECTION, MAX_ITERATIONS)
 
 AST = "ast/"
 CSK = "csk/3155919-2167789/CSKS4_SCS_B_WR_03_VV_RA_SF_20141001061215_20141001061230.h5"
@@ -68,9 +69,7 @@ def run_server(port=8080):
 threading.Thread(target=run_server, daemon=True).start()
 
 
-class IngestTests(unittest.TestCase):
-    def setUp(self):
-        setUpTest()
+class IngestTests(AprocTests):
 
     def wait_for(self, status: StatusInfo) -> StatusInfo:
         i: int = 0

--- a/test/aproc_ingest_tests_filesystem.py
+++ b/test/aproc_ingest_tests_filesystem.py
@@ -16,6 +16,7 @@ ROOT = "/inputs"
 class Tests(IngestTests):
 
     def setUp(self) -> None:
+        super().setUp()
         shutil.rmtree(os.path.join("test", "inputs", "many"), ignore_errors=True)
 
     def test_async_ingest_tif(self):  # Driver TIF

--- a/test/aproc_tests.py
+++ b/test/aproc_tests.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+import unittest
+from test.utils import s3_access_key, s3_access_key_id, s3_bucket, s3_endpoint_url, s3_region, index_collection_prefix, index_endpoint_url, COLLECTION
+import elasticsearch
+
+
+class TimedTests(unittest.TestCase):
+    def setUp(self):
+        self.tick = datetime.now()
+
+    def tearDown(self):
+        self.tock = datetime.now()
+        diff = self.tock - self.tick
+        print(f"Test {self._testMethodName} took {diff.total_seconds()}s")
+
+
+class AprocTests(TimedTests):
+
+    def get_client(self):
+        from boto3 import Session
+        session = Session(
+                aws_access_key_id=s3_access_key_id,
+                aws_secret_access_key=s3_access_key,
+                region_name=s3_region)
+        return session.client("s3", endpoint_url=s3_endpoint_url)
+
+    def setUpESandMinio(self):
+        import airs.core.product_registration as rs
+        es = elasticsearch.Elasticsearch(index_endpoint_url)
+        for collection in [COLLECTION, "collection1", "collection2", "collection3"]:
+            try:
+                # Clean the index
+                es.indices.delete(index=index_collection_prefix + "_" + collection)
+            except Exception:
+                ...
+            try:
+                objects = self.get_client().list_objects(Bucket=s3_bucket, Prefix=rs.get_assets_relative_path(collection, ID))
+                for object in objects["Contents"]:
+                    self.get_client().delete_object(Bucket=s3_bucket, Key=object["Key"])
+                self.get_client().delete_object(Bucket=s3_bucket, Key=rs.get_item_relative_path(collection, ID))
+            except Exception as e:
+                ...
+            try:
+                objects = self.get_client().list_objects(Bucket=s3_bucket, Prefix=rs.get_assets_relative_path(collection, ID_MANAGED))
+                for object in objects["Contents"]:
+                    self.get_client().delete_object(Bucket=s3_bucket, Key=object["Key"])
+                self.get_client().delete_object(Bucket=s3_bucket, Key=rs.get_item_relative_path(collection, ID))
+            except Exception as e:
+                ...
+
+    def setUp(self):
+        super().setUp()
+        self.setUpESandMinio()
+
+    def tearDown(self):
+        super().tearDown()

--- a/test/aproc_tests.py
+++ b/test/aproc_tests.py
@@ -33,14 +33,14 @@ class AprocTests(TimedTests):
             try:
                 # Clean the index
                 es.indices.delete(index=index_collection_prefix + "_" + collection)
-            except Exception as e:
+            except Exception:
                 ...
             try:
                 objects = self.get_client().list_objects(Bucket=s3_bucket, Prefix=collection)
                 for object in objects["Contents"]:
                     self.get_client().delete_object(Bucket=s3_bucket, Key=object["Key"])
                 self.get_client().delete_object(Bucket=s3_bucket, Key=rs.get_item_relative_path(collection, ID))
-            except Exception as e:
+            except Exception:
                 ...
 
     def setUp(self):

--- a/test/aproc_tests.py
+++ b/test/aproc_tests.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+import json
 import unittest
-from test.utils import s3_access_key, s3_access_key_id, s3_bucket, s3_endpoint_url, s3_region, index_collection_prefix, index_endpoint_url, COLLECTION
+from extensions.aproc.proc.drivers.exceptions import DriverException
+from test.utils import ID, ID_MANAGED, s3_access_key, s3_access_key_id, s3_bucket, s3_endpoint_url, s3_region, index_collection_prefix, index_endpoint_url, COLLECTION
 import elasticsearch
 
 
@@ -31,17 +33,10 @@ class AprocTests(TimedTests):
             try:
                 # Clean the index
                 es.indices.delete(index=index_collection_prefix + "_" + collection)
-            except Exception:
-                ...
-            try:
-                objects = self.get_client().list_objects(Bucket=s3_bucket, Prefix=rs.get_assets_relative_path(collection, ID))
-                for object in objects["Contents"]:
-                    self.get_client().delete_object(Bucket=s3_bucket, Key=object["Key"])
-                self.get_client().delete_object(Bucket=s3_bucket, Key=rs.get_item_relative_path(collection, ID))
             except Exception as e:
                 ...
             try:
-                objects = self.get_client().list_objects(Bucket=s3_bucket, Prefix=rs.get_assets_relative_path(collection, ID_MANAGED))
+                objects = self.get_client().list_objects(Bucket=s3_bucket, Prefix=collection)
                 for object in objects["Contents"]:
                     self.get_client().delete_object(Bucket=s3_bucket, Key=object["Key"])
                 self.get_client().delete_object(Bucket=s3_bucket, Key=rs.get_item_relative_path(collection, ID))

--- a/test/tests_g3.sh
+++ b/test/tests_g3.sh
@@ -7,7 +7,7 @@ docker build -f docker/Dockerfile-tests . -t pythontests
 . ./test/env.sh
 
 echo "run test.aproc_enrich_tests"
-docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.aproc_enrich_tests
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.aproc_enrich_tests -v
 
 echo "run test.aproc_dc3build_tests"
-docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.aproc_dc3build_tests
+docker run --rm -v `pwd`:/app/  --network compose_aias pythontests python3 -m test.aproc_dc3build_tests -v

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,6 +1,5 @@
 import json
 import unittest
-import elasticsearch
 import os
 import time
 import unicodedata
@@ -65,39 +64,6 @@ AccessManager.init(AprocConfiguration.settings.access_manager)
 IngestConfiguration.init(configuration_file='./conf/drivers.yaml')
 DriverManager.init(summary.id, IngestConfiguration.settings.drivers)
 
-
-def get_client():
-    from boto3 import Session
-    session = Session(
-            aws_access_key_id=s3_access_key_id,
-            aws_secret_access_key=s3_access_key,
-            region_name=s3_region)
-    return session.client("s3", endpoint_url=s3_endpoint_url)
-
-
-def setUpTest():
-    import airs.core.product_registration as rs
-    es = elasticsearch.Elasticsearch(index_endpoint_url)
-    for collection in [COLLECTION, "collection1", "collection2", "collection3"]:
-        try:
-            # Clean the index
-            es.indices.delete(index=index_collection_prefix + "_" + collection)
-        except Exception:
-            ...
-        try:
-            objects = get_client().list_objects(Bucket=s3_bucket, Prefix=rs.get_assets_relative_path(collection, ID))
-            for object in objects["Contents"]:
-                get_client().delete_object(Bucket=s3_bucket, Key=object["Key"])
-            get_client().delete_object(Bucket=s3_bucket, Key=rs.get_item_relative_path(collection, ID))
-        except Exception as e:
-            ...
-        try:
-            objects = get_client().list_objects(Bucket=s3_bucket, Prefix=rs.get_assets_relative_path(collection, ID_MANAGED))
-            for object in objects["Contents"]:
-                get_client().delete_object(Bucket=s3_bucket, Key=object["Key"])
-            get_client().delete_object(Bucket=s3_bucket, Key=rs.get_item_relative_path(collection, ID))
-        except Exception as e:
-            ...
 
 
 def dir_to_list(dirname, parent={}):


### PR DESCRIPTION
**Before**
- the csk driver uses stream on the data to extract the preview. It is very slow
- the capella driver was not using the thumbnail (which has the overview size)
- 
**Now**
- the csk drivers uses a local version
- the capella driver uses the thumb
 
**Side changes:**
- measure test durations