### PR TITLE
Fix/#518 s3.pull

### DIFF
--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -122,7 +122,7 @@ class S3Storage(AbstractStorage):
 
     def pull(self, href: str, dst: str):
         import botocore.client
-        LOGGER.debug("Downloading from %s to %s", href, dst)
+        print("Downloading from %s to %s", href, dst)
         client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
         path = self.__get_href_key(href)
 
@@ -135,23 +135,23 @@ class S3Storage(AbstractStorage):
                         continue
                     if path == obj['Key']:
                         # The href points to a file and the path is the exact location for the file, we remove the full prefix
-                        LOGGER.debug("The href points to a file")
                         local_file_path = dst
                     else:
                         # The href points to a folder, we remove the href prefix only
-                        LOGGER.debug("The href points to a folder")
                         prefix_to_remove = self.__get_href_key(href).removesuffix("/") + "/"
                         local_file_path = os.path.join(dst, obj['Key'].removeprefix(prefix_to_remove))
 
+                    print("Downloading S3 object %s to local file %s", obj['Key'], local_file_path)
                     # Create local directory structure
                     if os.path.dirname(local_file_path):
                         os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
                     # Download the file
-                    LOGGER.debug("Downloading S3 object %s to local file %s", obj['Key'], local_file_path)
                     obj = client.get_object(Bucket=self.get_configuration().bucket, Key=obj['Key'])
                     with open(local_file_path, "wb") as f:
                         for chunk in obj['Body'].iter_chunks(50 * 1024):
                             f.write(chunk)
+                    if local_file_path == dst:
+                        break  # If we were asked to download a single file, we can stop after the first one
 
     def push(self, href: str, dst: str, content_type: str | None = None):
         import botocore.client

--- a/python/aias_common/access/storages/s3.py
+++ b/python/aias_common/access/storages/s3.py
@@ -122,7 +122,6 @@ class S3Storage(AbstractStorage):
 
     def pull(self, href: str, dst: str):
         import botocore.client
-        print("Downloading from %s to %s", href, dst)
         client: botocore.client.BaseClient = self.get_storage_parameters()["client"]
         path = self.__get_href_key(href)
 
@@ -141,7 +140,7 @@ class S3Storage(AbstractStorage):
                         prefix_to_remove = self.__get_href_key(href).removesuffix("/") + "/"
                         local_file_path = os.path.join(dst, obj['Key'].removeprefix(prefix_to_remove))
 
-                    print("Downloading S3 object %s to local file %s", obj['Key'], local_file_path)
+                    LOGGER.debug("Downloading S3 object %s to local file %s", obj['Key'], local_file_path)
                     # Create local directory structure
                     if os.path.dirname(local_file_path):
                         os.makedirs(os.path.dirname(local_file_path), exist_ok=True)

--- a/test/access_manager_tests.py
+++ b/test/access_manager_tests.py
@@ -18,7 +18,8 @@ MINIO_HOST = "minio"
 
 S3_RO_DIR_SLASH = "https://storage.googleapis.com/gisaia-public/test-aias/spot6/"
 S3_RO_DIR_NO_SLASH = "https://storage.googleapis.com/gisaia-public/test-aias/ast"
-S3_RO_FILE = "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tif"
+S3_RO_FILE = "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw"
+S3_RO_FILE2 = "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tif"
 S3_RO_SMALL_DIR = "https://storage.googleapis.com/gisaia-public/test-aias/spot6/PROD_SPOT6_001/LIBRARY"
 S3_RO_DIR = "http://" + MINIO_HOST + ":9000/downloads/readonly/"
 S3_RW_DIR = "http://" + MINIO_HOST + ":9000/downloads/readwrite/"
@@ -173,7 +174,7 @@ NOT_EXISTS = [
 
 CAN_PULL = [
     GS_RO_FILE,
-    S3_RO_FILE,
+    S3_RO_FILE2,
     HTTPS_RO_FILE,
     #    GS_RO_SMALL_DIR, // todo fix pull of directories for gs. See issue #366
     S3_RO_SMALL_DIR

--- a/test/access_manager_tests.py
+++ b/test/access_manager_tests.py
@@ -18,7 +18,7 @@ MINIO_HOST = "minio"
 
 S3_RO_DIR_SLASH = "https://storage.googleapis.com/gisaia-public/test-aias/spot6/"
 S3_RO_DIR_NO_SLASH = "https://storage.googleapis.com/gisaia-public/test-aias/ast"
-S3_RO_FILE = "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tfw"
+S3_RO_FILE = "https://storage.googleapis.com/gisaia-public/test-aias/ast/AST_L1B_00307242024224227_20240729075840_2355295.VNIR_Swath.ImageData3N.tif"
 S3_RO_SMALL_DIR = "https://storage.googleapis.com/gisaia-public/test-aias/spot6/PROD_SPOT6_001/LIBRARY"
 S3_RO_DIR = "http://" + MINIO_HOST + ":9000/downloads/readonly/"
 S3_RW_DIR = "http://" + MINIO_HOST + ":9000/downloads/readwrite/"


### PR DESCRIPTION
See ticket for description:
Fix #518 

Changes:
- pull stops when requested resource is a file, do not loop
- change test with a file that has a prefix brother to make sure the fix is ok
- remove debug logs that were not meaningfull