### PR TITLE
Fix: test date format for axelspace and fix all CVEs

### DIFF
--- a/docker/Dockerfile-agate
+++ b/docker/Dockerfile-agate
@@ -1,5 +1,4 @@
 FROM python:3.14-alpine3.24
-RUN pip3 install --no-cache-dir --upgrade pip setuptools
 
 ARG version="latest"
 ENV AIAS_VERSION=${version}

--- a/docker/Dockerfile-airs
+++ b/docker/Dockerfile-airs
@@ -1,5 +1,4 @@
 FROM python:3.14-alpine3.24
-RUN pip3 install --no-cache-dir --upgrade pip setuptools
 
 ARG version="0.0"
 ENV AIAS_VERSION=${version}

--- a/docker/Dockerfile-aproc-proc
+++ b/docker/Dockerfile-aproc-proc
@@ -13,9 +13,7 @@ WORKDIR /usr/src
 
 # Python runtime behavior:
 # - do not create .pyc files
-# - send logs directly to stdout/stderr
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
 
 # Virtual environment location used during build and copied later to runtime
 ENV VIRTUAL_ENV=/opt/aproc

--- a/docker/Dockerfile-aproc-proc
+++ b/docker/Dockerfile-aproc-proc
@@ -1,4 +1,6 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-full-3.13.1
+# Builder stage
+FROM ghcr.io/osgeo/gdal:ubuntu-full-3.13.2 AS builder
+
 ARG version="0.0"
 ENV AIAS_VERSION=${version}
 
@@ -6,35 +8,57 @@ LABEL io.arlas.aproc-proc.version=${version}
 LABEL vendor="Gisaïa"
 LABEL description="This container serves ARLAS APROC Processing"
 
+# Base working directory for build operations
 WORKDIR /usr/src
 
+# Python runtime behavior:
+# - do not create .pyc files
+# - send logs directly to stdout/stderr
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update --no-install-recommends \
-    && apt-get install -y python3.14-dev python3.14-venv \
-    && apt-get install -y g++ make  \
-    && apt-get install -y libtiff-dev imagemagick  \
-    && apt-get install -y libhdf5-dev libhdf5-serial-dev netcdf-bin libnetcdf-dev linux-libc-dev \
-    && apt-get upgrade -y \
-    && apt-get clean && apt-get remove -y --auto-remove curl
+# Virtual environment location used during build and copied later to runtime
+ENV VIRTUAL_ENV=/opt/aproc
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
-USER 1000
-WORKDIR /app
+# Install build dependencies only:
+# - python3.14-dev / venv for Python package builds
+# - g++ / make for native compilation
+# - libtiff-dev for srtm4 build (tiffio.h)
+# - linux-libc-dev kept only in builder for compilation needs
+# - other native libs required by project dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.14-dev \
+        python3.14-venv \
+        g++ \
+        make \
+        libtiff-dev \
+        imagemagick \
+        libhdf5-dev \
+        libhdf5-serial-dev \
+        netcdf-bin \
+        libnetcdf-dev \
+        linux-libc-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN python -m venv --system-site-packages aproc
+# Create the Python virtual environment using system site packages
+RUN python -m venv --system-site-packages ${VIRTUAL_ENV}
 
+# Copy dependency files first to improve Docker layer caching
 COPY ./python/requirements.aias.services.txt /app/
-
 COPY ./python/aias_common/requirements.aias_common.txt /app/
-
 COPY ./python/aproc/requirements.aproc.txt /app/
-RUN aproc/bin/pip install --no-cache-dir -r /app/requirements.aproc.txt 
 
+# Install core Python dependencies into the virtual environment
+RUN ${VIRTUAL_ENV}/bin/pip install --no-cache-dir -r /app/requirements.aproc.txt
+
+# Copy and install extension dependencies
 COPY ./python/extensions/requirements.aproc.ext.txt /app/
-RUN aproc/bin/pip install --no-cache-dir -r /app/requirements.aproc.ext.txt 
+RUN ${VIRTUAL_ENV}/bin/pip install --no-cache-dir -r /app/requirements.aproc.ext.txt
 
-
+# Copy application source code and configuration files
 COPY ./python/aproc /app/aproc
 COPY ./python/extensions /app/extensions
 COPY ./python/aias_common /app/aias_common
@@ -44,9 +68,71 @@ COPY ./python/airs/core /app/airs/core
 COPY ./docker/materials/scripts/aproc-proc/start.sh /app/
 COPY ./docker/materials/scripts/aproc-proc/ping.sh /app/
 
+# Ensure startup scripts are executable
+RUN chmod +x /app/start.sh /app/ping.sh
+
+# Runtime stage
+FROM ghcr.io/osgeo/gdal:ubuntu-full-3.13.2 AS runtime
+
+ARG version="0.0"
+ENV AIAS_VERSION=${version}
+
+LABEL io.arlas.aproc-proc.version=${version}
+LABEL vendor="Gisaïa"
+LABEL description="This container serves ARLAS APROC Processing"
+
+# Final application working directory
+WORKDIR /app
+
+# Python runtime behavior:
+# - do not create .pyc files
+# - send logs directly to stdout/stderr
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Reuse the virtual environment created in the builder stage
+ENV VIRTUAL_ENV=/opt/aproc
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+# Install runtime-only OS packages.
+# No compilers or development headers are kept here.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.14 \
+        python3.14-venv \
+        imagemagick \
+        netcdf-bin \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Remove pebble from the final runtime image because it is not needed
+# by the application and was reported by the vulnerability scan
+RUN rm -f /usr/bin/pebble
+
+# Copy the prepared virtual environment from the builder stage
+COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+
+# Copy application code, assets, configuration, and scripts
+COPY --from=builder /app/aproc /app/aproc
+COPY --from=builder /app/extensions /app/extensions
+COPY --from=builder /app/aias_common /app/aias_common
+COPY --from=builder /app/conf /app/conf
+COPY --from=builder /app/assets /app/assets
+COPY --from=builder /app/airs/core /app/airs/core
+COPY --from=builder /app/start.sh /app/start.sh
+COPY --from=builder /app/ping.sh /app/ping.sh
+
+# Ensure runtime scripts are executable
+RUN chmod +x /app/start.sh /app/ping.sh
+
+# Application runtime configuration
 ENV APROC_CONFIGURATION_FILE=/app/conf/aproc.yaml
 ENV ARLASEO_MAPPING_URL=/app/conf/mapping.json
 ENV DOWNLOAD_MAPPING_URL=/app/conf/downloads_mapping.json
 ENV PYTHONPATH=/app
 
+# Run the container as a non-root user
+USER 1000
+
+# Default container entrypoint
 ENTRYPOINT ["./start.sh"]

--- a/docker/Dockerfile-fam
+++ b/docker/Dockerfile-fam
@@ -1,5 +1,4 @@
 FROM python:3.14-alpine3.24
-RUN pip3 install --no-cache-dir --upgrade  pip setuptools
 
 ARG version="0.0"
 ENV AIAS_VERSION=${version}

--- a/docker/Dockerfile-stac-geodes
+++ b/docker/Dockerfile-stac-geodes
@@ -1,5 +1,4 @@
 FROM python:3.14-alpine3.24
-RUN pip3 install --no-cache-dir --upgrade pip setuptools
 
 ARG version="0.0"
 ENV AIAS_VERSION=${version}

--- a/docker/materials/scripts/aproc-proc/start.sh
+++ b/docker/materials/scripts/aproc-proc/start.sh
@@ -10,5 +10,5 @@ else
     echo "Starting worker for default queue: $QUEUE_NAMES"
 fi
 
-. aproc/bin/activate
+. /opt/aproc/bin/activate
 celery -A aproc.core.processes.processes:APROC_CELERY_APP worker -Q ${QUEUE_NAMES} -E -c 1 -n worker@%h $*

--- a/python/aproc/requirements.aproc.txt
+++ b/python/aproc/requirements.aproc.txt
@@ -3,7 +3,7 @@ celery[redis]==5.3.1
 celery==5.3.1
 elasticsearch==8.9.0
 jsonref==1.1.0
-pillow==12.2.0
+pillow==12.3.0
 redis==5.0.0
 -r requirements.aias_common.txt
 -r requirements.aias.services.txt

--- a/python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py
@@ -112,10 +112,8 @@ class Driver(IngestDriver):
             centroid = merged_polygons.centroid.xy
             bbox = merged_polygons.bounds
 
-            start_date_time = metadata["EOMetadata"]["acquisitionDateTime"]["acquisitionStartDateTime"]
-            start_date_time = datetime.strptime(start_date_time, "%Y-%m-%dT%H:%M:%S%z")
-            end_date_time = metadata["EOMetadata"]["acquisitionDateTime"]["acquisitionEndDateTime"]
-            end_date_time = datetime.strptime(end_date_time, "%Y-%m-%dT%H:%M:%S.%f%z")
+            start_date_time = self._parse_dt(metadata["EOMetadata"]["acquisitionDateTime"]["acquisitionStartDateTime"])
+            end_date_time = self._parse_dt(metadata["EOMetadata"]["acquisitionDateTime"]["acquisitionEndDateTime"])
 
         except KeyError as ke:
             raise DriverException(f"Invalid metadata file {self.md_path}: a key is missing: {ke.args[0]}")
@@ -198,3 +196,11 @@ class Driver(IngestDriver):
             tile_md = json.load(fb)["imageTileMetadata"]
 
         return tile_md
+
+    def _parse_dt(self, value: str) -> datetime:
+        for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z"):
+            try:
+                return datetime.strptime(value, fmt)
+            except ValueError:
+                pass
+        raise ValueError(f"Unsupported datetime format: {value}")

--- a/python/extensions/requirements.aproc.ext.txt
+++ b/python/extensions/requirements.aproc.ext.txt
@@ -3,7 +3,7 @@ cryptography==49.0.0
 dask==2026.6.0
 h5py==3.16.0
 matplotlib==3.11.0
-pillow==12.2.0
+pillow==12.3.0
 pvl==1.3.2
 pyproj==3.7.2
 rioxarray==0.17.0

--- a/python/extensions/requirements.aproc.ext.txt
+++ b/python/extensions/requirements.aproc.ext.txt
@@ -1,5 +1,5 @@
 boto3==1.43.32
-cryptography==49.0.0
+cryptography==50.0.0
 dask==2026.6.0
 h5py==3.16.0
 matplotlib==3.11.0

--- a/python/fam/requirements.fam.txt
+++ b/python/fam/requirements.fam.txt
@@ -1,3 +1,3 @@
-pillow==12.2.0
+pillow==12.3.0
 -r requirements.aias_common.txt
 -r requirements.aias.services.txt

--- a/python/requirements.aias.services.txt
+++ b/python/requirements.aias.services.txt
@@ -8,7 +8,7 @@ requests==2.32.4
 attrs==23.1.0
 ecs-logging==2.2.0
 PyJWT==2.13.0
-cryptography==49.0.0
+cryptography==50.0.0
 python-dateutil==2.8.2
 fastapi-utilities==0.3.1
 python-multipart==0.0.31

--- a/test/requirements.tests.txt
+++ b/test/requirements.tests.txt
@@ -13,7 +13,7 @@ pygeohash==1.2.0
 celery==5.3.1
 celery[redis]==5.3.1
 jsonref==1.1.0
-pillow==12.2.0
+pillow==12.3.0
 typer==0.9.0
 fastapi-utilities==0.3.1
 pytest==8.4.2


### PR DESCRIPTION
This PR fixes a date parsing issue in the Axelspace driver by introducing a flexible date format parser. It also updates the GDAL base image version in the APROC Dockerfile from 3.13.1 to 3.13.2, implements multi-stage Docker builds for better image optimization, and bumps the Pillow dependency from 12.2.0 to 12.3.0 across multiple components.
- All CVEs are below HIGH and CRITICAL in all services.
- All tests success

- ## Key Changes
**1. Axelspace Driver Fix** (`python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py`)
   - Introduced a new `_parse_dt()` method that handles multiple datetime formats
   - Replaces hardcoded format parsing with flexible format detection
   - Handles both `.%f%z` (with microseconds) and `%z` (without microseconds) formats
   - This resolves inconsistencies in how Axelspace metadata timestamps are formatted

**2. APROC Dockerfile Optimization** (`docker/Dockerfile-aproc-proc`)
   - Upgraded GDAL base image from `3.13.1` to `3.13.2`
   - Implemented multi-stage build pattern (builder + runtime stages) for smaller final image
   - Separated build dependencies from runtime dependencies
   - Improved caching by reorganizing COPY and RUN commands
   - Added comments for clarity and maintainability
   - Removed `pebble` binary from runtime stage (vulnerability scan finding)

**3. Pillow Dependency Updates**
   - Bumped Pillow from 12.2.0 to 12.3.0 across:
     - `python/aproc/requirements.aproc.txt`
     - `python/extensions/requirements.aproc.ext.txt`
     - `python/fam/requirements.fam.txt`
     - `test/requirements.tests.txt`

**4. Alpine Dockerfile Cleanups** 
   - Removed redundant and root user `pip install --upgrade pip setuptools` from:
     - `docker/Dockerfile-agate`
     - `docker/Dockerfile-airs`
     - `docker/Dockerfile-fam`
     - `docker/Dockerfile-stac-geodes`

