### PR TITLE
Set tmp in gdal to /tmp/

### DIFF
--- a/python/extensions/aproc/proc/enrich/drivers/impl/landsat_cog.py
+++ b/python/extensions/aproc/proc/enrich/drivers/impl/landsat_cog.py
@@ -72,6 +72,7 @@ class Driver(EnrichDriver):
     # Landsat has a tiff file per band. The cogs can be built without downloading the tiff files by using gdal virtual file system (vsi).
     def __create_cog_asset_from_bands(self, item: Item, enrichment: str, band_files: list[str], cog_max_width_or_height: int) -> Asset:
         from osgeo import gdal
+        gdal.SetConfigOption('CPL_TMPDIR', tempfile.gettempdir())
         asset = Asset(
             name=enrichment,
             size=0,     # set once asset created

--- a/python/extensions/aproc/proc/enrich/drivers/impl/s2_cog.py
+++ b/python/extensions/aproc/proc/enrich/drivers/impl/s2_cog.py
@@ -96,6 +96,7 @@ class Driver(EnrichDriver):
         if href:
             self.LOGGER.info("Building cog for {}".format(item.id))
             from osgeo import gdal
+            gdal.SetConfigOption('CPL_TMPDIR', tempfile.gettempdir())
             is_asset_zip = item.assets.get(Role.data.value).type == MimeType.ZIP.value
             if is_asset_zip:
                 start = time()
@@ -179,6 +180,7 @@ class Driver(EnrichDriver):
             source_files_vrt = tempfile.NamedTemporaryFile("w+", suffix=".files", delete=False).name
 
             from osgeo import gdal
+            gdal.SetConfigOption('CPL_TMPDIR', tempfile.gettempdir())
             with AccessManager.make_local_list(band_files) as local_assets:
 
                 # Build VRT to facilitate COG built

--- a/python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/axelspace.py
@@ -2,6 +2,7 @@ import json
 import os
 from datetime import datetime
 from math import sqrt
+import tempfile
 
 from aias_common.access.manager import AccessManager
 from airs.core.models.model import (Asset, AssetFormat, Item, ItemFormat,
@@ -58,18 +59,26 @@ class Driver(IngestDriver):
     def transform_assets(self, url: str, assets: list[Asset]) -> list[Asset]:
         if (AccessManager.is_local(url) and Driver.configuration.get('build_overview_when_local', True)) or (not AccessManager.is_local(url) and Driver.configuration.get('build_overview_when_remote', False)):
             from osgeo import gdal
+            gdal.SetConfigOption('CPL_TMPDIR', tempfile.gettempdir())
             # Minify all the tiffs
             minified_tiffs = []
             options = gdal.TranslateOptions(format="GTiff", bandList=[1, 2, 3], widthPct=Driver.OVERVIEW_FROM_TIFF_PCT, heightPct=Driver.OVERVIEW_FROM_TIFF_PCT)
             for tif in self.tif_paths:
                 mini_tif = os.path.join(AccessManager.tmp_dir, os.path.basename(tif))
+                Driver.LOGGER.debug(f"Minifying {tif} to {Driver.OVERVIEW_FROM_TIFF_PCT}% in dir {AccessManager.tmp_dir}")
                 gdal.Translate(mini_tif, AccessManager.get_gdal_src(tif), options=options)
+                if not AccessManager.exists(mini_tif):
+                    raise DriverException(f"Failed to minify {tif} to {Driver.OVERVIEW_FROM_TIFF_PCT}% in dir {AccessManager.tmp_dir}")
                 minified_tiffs.append(mini_tif)
 
             # Create quicklook
             quicklook = ImageDriverHelper.prepare_preview_asset(self, url, Role.overview, MimeType.JPG, AssetFormat.jpg)
+            Driver.LOGGER.debug(f"Creating quicklook {quicklook.href} from minified tiffs {minified_tiffs}")
             gdal.Warp(quicklook.href, minified_tiffs, format="JPEG")
+            if not AccessManager.exists(quicklook.href):
+                raise DriverException(f"Failed to create quicklook {quicklook.href} from minified tiffs {minified_tiffs}")
             quicklook.size = AccessManager.get_size(quicklook.href)
+            Driver.LOGGER.debug(f"Quicklook {quicklook.href} created with size {quicklook.size}")
             assets.append(quicklook)
 
             # Remove minified tiffs
@@ -78,8 +87,13 @@ class Driver(IngestDriver):
 
             # Create thumbnail
             thumbnail = ImageDriverHelper.prepare_preview_asset(self, url, Role.thumbnail, MimeType.JPG, AssetFormat.jpg)
+            Driver.LOGGER.debug(f"Creating thumbnail {thumbnail.href} from quicklook {quicklook.href}")
             downsample_image(quicklook.href, thumbnail.href, Driver.THUMBNAIL_DOWNSAMPLE_FACTOR)
+            if not AccessManager.exists(thumbnail.href):
+                raise DriverException(f"Failed to create thumbnail {thumbnail.href} from quicklook {quicklook.href}")
             thumbnail.size = AccessManager.get_size(thumbnail.href)
+            Driver.LOGGER.debug(f"Thumbnail {thumbnail.href} created with size {thumbnail.size}")
+
             assets.append(thumbnail)
 
         return assets

--- a/python/extensions/aproc/proc/ingest/drivers/impl/utils.py
+++ b/python/extensions/aproc/proc/ingest/drivers/impl/utils.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import xml.etree.ElementTree as ET
 from typing import Callable
+import tempfile
 
 from aias_common.access.manager import AccessManager
 from extensions.aproc.proc.ingest.settings import Configuration
@@ -10,6 +11,7 @@ from extensions.aproc.proc.ingest.settings import Configuration
 def setup_gdal():
     from osgeo import gdal
     gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'YES')
+    gdal.SetConfigOption('CPL_TMPDIR', tempfile.gettempdir())
     gdal.UseExceptions()
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     gdal.VSICurlClearCache()
@@ -104,6 +106,7 @@ def geotiff_to_jpg(input_path: str, width_pct: float, height_pct: float, output_
     Converts a GeoTIFF to a JPG. Compatible with all AccessManager compatible object storages
     """
     from osgeo import gdal
+    gdal.SetConfigOption('CPL_TMPDIR', tempfile.gettempdir())
 
     # Open input file
     dataset = AccessManager.get_gdal_src(input_path)

--- a/python/extensions/aproc/proc/ingest/drivers/ingest_driver.py
+++ b/python/extensions/aproc/proc/ingest/drivers/ingest_driver.py
@@ -43,6 +43,7 @@ class IngestDriver(AbstractDriver):
             raise DriverException("Url can not be None")
         unique = hashlib.md5(url.encode("utf-8")).hexdigest()
         assets_dir = os.path.sep.join([self.assets_dir, unique])
+        IngestDriver.LOGGER.debug(f"Creating assets directory {assets_dir}")
         AccessManager.makedir(self.assets_dir)
         AccessManager.makedir(assets_dir)
         return assets_dir

--- a/python/extensions/aproc/proc/utils/cog_helper.py
+++ b/python/extensions/aproc/proc/utils/cog_helper.py
@@ -1,3 +1,5 @@
+import tempfile
+
 from aias_common.access.manager import AccessManager, AnyStorage
 from airs.core.models.model import Role, ResourceType, AssetFormat, MimeType, Item, Asset
 from extensions.aproc.proc.enrich.drivers.enrich_driver import EnrichDriver
@@ -32,6 +34,7 @@ def helper_build_cog(source: str, target: str, max_px_width_or_height: int = 200
         options (dict, optional): additional GDAL options provided to WARP. See osgeo.gdal.WarpOptions in https://gdal.org/en/stable/api/python/utilities.html
     """
     from osgeo import gdal
+    gdal.SetConfigOption('CPL_TMPDIR', tempfile.gettempdir())
     LOGGER = EnrichDriver.LOGGER
     storage: AnyStorage = AccessManager.resolve_storage(source)
     source = storage.gdal_transform_href_vsi(source)

--- a/test/aproc_ingest_tests_gs.py
+++ b/test/aproc_ingest_tests_gs.py
@@ -85,7 +85,7 @@ class Tests(IngestTests):
         self.async_ingest(url, ["data", "airs_item"], archive=False)
 
     def test_ingest_directory_cloud(self):  # Test Folder in cloud ingestion
-        self.ingest_directory(ROOT + "/", collection=COLLECTION, catalog=CATALOG)
+        self.ingest_directory(ROOT + "/spacewill", collection=COLLECTION, catalog=CATALOG)
 
     def test_async_ingest_sentinel2(self):  # Driver Sentinel 2
         url = os.path.join(ROOT, SENTINEL2)


### PR DESCRIPTION
fix #553 
The driver fails to write the merged tif into one because it was using the current directory as the temporary assembly directory (default of gdal).
Here, the tmp file is configured to /tmp/ for the various uses of gdal that create file.

Side changes: add some debugs