### PR TITLE
Chore: fix CVE setuptools

### DIFF
--- a/docker/Dockerfile-agate
+++ b/docker/Dockerfile-agate
@@ -9,6 +9,12 @@ LABEL description="This container serves ARLAS AGATE"
 
 RUN apk update && apk add  --no-cache --upgrade libexpat curl gcc python3-dev musl-dev linux-headers libcrypto3 libssl3
 
+#Clean SBOM pip to fix false positive CVE CVE-2025-47273 about setuptools
+#pip show setuptools → “not found” (because it is not installed via pip).
+#apk info py3-setuptools → 82.0.1 (system version).
+#SBOM bom.cdx.json → setuptools@70.3.0 (version documented at the time pip was built but not really instaled).
+RUN rm -f /usr/local/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json
+
 RUN addgroup -g 1000 arlasgroup && \
     adduser -D -u 1000 -G arlasgroup arlasuser
 USER 1000
@@ -23,6 +29,7 @@ COPY ./python/agate /app/agate
 COPY ./python/aias_common /app/aias_common
 COPY ./conf/agate.yaml /app/conf/
 COPY ./docker/materials/scripts/agate/start.sh /app/
+
 
 EXPOSE 8004
 ENTRYPOINT ["./start.sh"]

--- a/docker/Dockerfile-airs
+++ b/docker/Dockerfile-airs
@@ -9,6 +9,12 @@ LABEL description="This container serves ARLAS AIRS"
 
 RUN apk update && apk add  --no-cache --upgrade libexpat curl gcc python3-dev musl-dev linux-headers libcrypto3 libssl3
 
+#Clean SBOM pip to fix false positive CVE CVE-2025-47273 about setuptools
+#pip show setuptools → “not found” (because it is not installed via pip).
+#apk info py3-setuptools → 82.0.1 (system version).
+#SBOM bom.cdx.json → setuptools@70.3.0 (version documented at the time pip was built but not really instaled).
+RUN rm -f /usr/local/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json
+
 RUN addgroup -g 1000 arlasgroup && \
     adduser -D -u 1000 -G arlasgroup arlasuser
 USER 1000

--- a/docker/Dockerfile-aproc-service
+++ b/docker/Dockerfile-aproc-service
@@ -10,6 +10,12 @@ RUN apk update \
     && apk add --no-cache python3 py3-pip \
     && apk --no-cache add --upgrade libexpat curl gcc python3-dev musl-dev linux-headers libcrypto3 libssl3
 
+#Clean SBOM pip to fix false positive CVE CVE-2025-47273 about setuptools
+#pip show setuptools → “not found” (because it is not installed via pip).
+#apk info py3-setuptools → 82.0.1 (system version).
+#SBOM bom.cdx.json → setuptools@70.3.0 (version documented at the time pip was built but not really instaled).
+RUN rm -f /usr/local/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json
+
 RUN addgroup -g 1000 arlasgroup && \
     adduser -D -u 1000 -G arlasgroup arlasuser
 
@@ -24,6 +30,7 @@ COPY ./python/aias_common/requirements.aias_common.txt /app/
 
 COPY ./python/aproc/requirements.aproc.txt /app/
 RUN aproc/bin/pip install --no-cache-dir -r requirements.aproc.txt
+RUN rm -f /app/aproc/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json
 
 
 COPY ./python/aproc /app/aproc

--- a/docker/Dockerfile-fam
+++ b/docker/Dockerfile-fam
@@ -9,6 +9,12 @@ LABEL description="This container serves ARLAS APROC FAM"
 
 RUN apk update && apk add  --no-cache --upgrade libexpat curl gcc python3-dev musl-dev linux-headers libcrypto3 libssl3
 
+#Clean SBOM pip to fix false positive CVE CVE-2025-47273 about setuptools
+#pip show setuptools → “not found” (because it is not installed via pip).
+#apk info py3-setuptools → 82.0.1 (system version).
+#SBOM bom.cdx.json → setuptools@70.3.0 (version documented at the time pip was built but not really instaled).
+RUN rm -f /usr/local/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json
+
 RUN addgroup -g 1000 arlasgroup && \
     adduser -D -u 1000 -G arlasgroup arlasuser
 USER 1000

--- a/docker/Dockerfile-stac-geodes
+++ b/docker/Dockerfile-stac-geodes
@@ -9,6 +9,12 @@ LABEL description="This container serves ARLAS GEODES STAC Sync"
 
 RUN apk update && apk --no-cache add curl
 
+#Clean SBOM pip to fix false positive CVE CVE-2025-47273 about setuptools
+#pip show setuptools → “not found” (because it is not installed via pip).
+#apk info py3-setuptools → 82.0.1 (system version).
+#SBOM bom.cdx.json → setuptools@70.3.0 (version documented at the time pip was built but not really instaled).
+RUN rm -f /usr/local/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json
+
 RUN addgroup -g 1000 arlasgroup && \
     adduser -D -u 1000 -G arlasgroup arlasuser
 USER 1000


### PR DESCRIPTION
Fix false positive CVE-2025-47273 about setuptools.
setuptools 70.3.0 is not present in the images, only in the SBOM file of pip